### PR TITLE
[codex] Add visual review comment tags

### DIFF
--- a/docs/codex/visual_review_io_methodology.md
+++ b/docs/codex/visual_review_io_methodology.md
@@ -67,6 +67,8 @@ Start with a small vocabulary. For visualization diagnostics, these are useful:
 visible
 not visible
 good
+notable / promising
+comment only
 shell/hollow
 needs work
 ```
@@ -83,6 +85,10 @@ physically suspicious
 ```
 
 Avoid making the checkbox list too long. Use the note field for rare cases.
+The note field should be valid on its own: reviewers must not have to mark
+`needs work` just to leave a neutral or positive comment. A `comment only`
+checkbox is useful when the reviewer wants to explicitly say that the row is
+included for discussion rather than as a requested fix.
 
 ## Generated Text
 
@@ -96,6 +102,7 @@ updated: 2026-05-10T12:34:56.000Z
 
 - balanced / single-plus-centered: visible, good
 - wide / single-plus-spatial-boundary: visible, shell/hollow | note: BC looks correct, but the cut surface reads as a shell.
+- volume / slice4=27: visible, notable / promising | note: visually good, but worth discussing.
 - core / single-plus-small-rho: not visible, needs work
 ```
 

--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,7 +4,39 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-10 during the `24^3 x 32` topological-density review pass.
+Last updated on 2026-05-10 during the visual-review UI comment-tag pass.
+
+## Active note: 2026-05-10 visual-review comment tags
+
+- Machine: `Akios-MacBook-Air.local`.
+- Workdir:
+
+```text
+/Users/akio/repository/VisualizingLQCD_v2/VisualizingLQCD.jl
+```
+
+- Branch: `codex/visual-review-comment-tags`.
+- Starting point: PR #25 was merged into `main`.
+- User feedback:
+  - the `needs work` checkbox was being used as a workaround for neutral or
+    positive comments;
+  - reviewers need an obvious place to leave comments that are not fix requests.
+- Implemented:
+  - add `notable / promising` and `comment only` checkboxes to both topology
+    visual review pages;
+  - clarify the note placeholder: note-only rows are copied into the generated
+    review text;
+  - update `docs/codex/visual_review_io_methodology.md` so future visual review
+    pages do not force comments through `needs work`.
+- Validation:
+  - generated a fixture visual-review page with
+    `scripts/topology_fixtures/render_su2_instanton_fixture_smoke.jl`;
+  - generated a config visual-review page with
+    `scripts/topology_fixtures/render_topological_density_config_review.jl`;
+  - confirmed the generated HTML contains `notable / promising`,
+    `comment only`, and the note-only placeholder text;
+  - passed `/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl`;
+  - passed `/Users/akio/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test()'`.
 
 ## Active note: 2026-05-10 `24^3 x 32` topological-density config review
 

--- a/scripts/topology_fixtures/render_su2_instanton_fixture_smoke.jl
+++ b/scripts/topology_fixtures/render_su2_instanton_fixture_smoke.jl
@@ -427,9 +427,11 @@ function write_review_controls(io, result)
 <label><input type="checkbox" data-kind="visible"> visible</label>
 <label><input type="checkbox" data-kind="missing"> not visible</label>
 <label><input type="checkbox" data-kind="good"> good</label>
+<label><input type="checkbox" data-kind="notable / promising"> notable / promising</label>
+<label><input type="checkbox" data-kind="comment only"> comment only</label>
 <label><input type="checkbox" data-kind="shell"> shell/hollow</label>
 <label><input type="checkbox" data-kind="needs-work"> needs work</label>
-<input class="review-note" type="text" data-note placeholder="short note for $label">
+<input class="review-note" type="text" data-note placeholder="optional comment for $label; note-only rows are copied too">
 </div>
 """)
 end

--- a/scripts/topology_fixtures/render_topological_density_config_review.jl
+++ b/scripts/topology_fixtures/render_topological_density_config_review.jl
@@ -308,9 +308,11 @@ pre { white-space: pre-wrap; color: #ddd; }
 <label><input type="checkbox" data-kind="visible"> visible</label>
 <label><input type="checkbox" data-kind="missing"> not visible</label>
 <label><input type="checkbox" data-kind="good"> good</label>
+<label><input type="checkbox" data-kind="notable / promising"> notable / promising</label>
+<label><input type="checkbox" data-kind="comment only"> comment only</label>
 <label><input type="checkbox" data-kind="shell"> shell/hollow</label>
 <label><input type="checkbox" data-kind="needs-work"> needs work</label>
-<input class="review-note" type="text" data-note placeholder="short note for $label">
+<input class="review-note" type="text" data-note placeholder="optional comment for $label; note-only rows are copied too">
 </div>
 </div>
 <details>


### PR DESCRIPTION
## Summary
- add neutral visual-review tags: notable / promising and comment only
- clarify that note-only rows are copied into the generated review text
- document the review UI convention so positive/neutral comments do not need to use needs-work

## Validation
- generated fixture review page: /private/tmp/VisualizingLQCD-review-comment-tags-fixture/view.html
- generated config review page: /private/tmp/VisualizingLQCD-review-comment-tags-config/view.html
- confirmed generated HTML contains the new labels and note-only placeholder
- /Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
- /Users/akio/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test()'
- git diff --check

## User action
Please review and merge if the new visual-review labels match the intended workflow.