### PR TITLE
[codex] Document topological density rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,38 @@ create_animation(
 )
 ```
 
+## Topological charge density
+
+Topological charge density can be rendered with the clover definition used by
+Gaugefields.jl. The density is signed, so the volume style draws positive and
+negative regions as separate solid meshes. The default volume threshold uses
+upper-tail `|q|` quantiles `(0.94, 0.999)`, and the mesh color encodes local
+`abs(q)`: positive charge progresses from yellow/orange to red, while negative
+charge progresses from cyan to blue.
+
+```julia
+topological_videoname = "topological_charge_density$(NX)$(NY)$(NZ)$(NT)beta$(β).mp4"
+
+create_animation(
+    NX, NY, NZ, NT, NC, topological_videoname;
+    beta=β,
+    filename=confname,
+    level_target=VisualizingLQCD.LEVEL_TARGET_TOPOLOGICAL_CHARGE_DENSITY,
+    render_style=VisualizingLQCD.RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME,
+    camera_motion=VisualizingLQCD.CAMERA_MOTION_ORBIT,
+    frame_mode=VisualizingLQCD.FRAME_MODE_SEQUENCE,
+    nloops=2,
+    framerate=8,
+    figure_size=(480, 480),
+)
+```
+
+The fourth-direction sequence is still Euclidean slice selection, not real-time
+evolution. Each output movie writes a metadata sidecar recording the slice map,
+threshold quantiles, color method, and observable definition. For a contour
+version instead of filled volume meshes, use
+`render_style=VisualizingLQCD.RENDER_STYLE_TOPOLOGICAL_CHARGE_SIGNED`.
+
 To rotate the camera during the movie, use `camera_motion=:orbit`. Orbit movies
 keep one fourth-direction slice fixed by default, so the shape is not changed by
 the slice sequence while the camera rotates. It also uses `viewmode=:fit` and

--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,7 +4,39 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-10 during the topological-volume `abs(q)` visual review.
+Last updated on 2026-05-10 during the topological-density documentation PR.
+
+## Active note: 2026-05-10 topological-density documentation
+
+- Machine: `Akios-MacBook-Air.local`.
+- Workdir:
+
+```text
+/Users/akio/repository/VisualizingLQCD_v2/VisualizingLQCD.jl
+```
+
+- Branch: `codex/topological-density-docs`.
+- Starting point: PR #34 was merged into `main`.
+- Goal:
+  - stop the accepted topological-density baseline from living only in Codex
+    status notes;
+  - document the user-facing API for rendering topological charge density;
+  - keep this as a low-risk documentation/test PR before making larger sample
+    artifacts.
+- Implemented:
+  - README now has a `Topological charge density` section;
+  - the README example uses
+    `LEVEL_TARGET_TOPOLOGICAL_CHARGE_DENSITY` with
+    `RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME`;
+  - the README explains the Euclidean fourth-direction sequence, signed
+    positive/negative volume meshes, `q0.940`/`q0.999` default threshold, local
+    `abs(q)` color mapping, and metadata sidecar;
+  - `scripts/topology_fixtures/README.md` now records the reviewed
+    topological-volume baseline and updates the movie-review command to the
+    accepted `nloops=2`, `framerate=8`, `figure_size=480`,
+    `show-render-progress=true` style;
+  - sample artifact tests now check that the topological-density README
+    examples remain present.
 
 ## Active note: 2026-05-10 topological-volume `abs(q)` visual review
 

--- a/scripts/topology_fixtures/README.md
+++ b/scripts/topology_fixtures/README.md
@@ -26,6 +26,12 @@ topological-density path, but writes one or more movies plus a review HTML page.
 It is a thin wrapper around `VisualizingLQCD.create_animation`, intended for
 small reviewed movie runs after the still-review page looks reasonable.
 
+For volume rendering, the current reviewed baseline uses a `q0.940` lower
+`|q|` body threshold and colors each sign by local `abs(q)`: positive charge is
+yellow/orange/red and negative charge is cyan/blue. This is the package default
+for `RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME`; pass `--level-quantiles` or
+`--color-quantile` only when deliberately testing a new visual threshold.
+
 The default smoke set is intentionally small. Use `--case-set debug` to add
 radius, off-center, spatial-boundary, same-sign DIGA, and three-lump checks.
 The display can also be tuned from the command line with `--style-preset`,
@@ -55,5 +61,5 @@ Run from the repository root:
 
 /Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_topological_density_config_review.jl --nx 24 --ny 24 --nz 24 --nt 32 --nc 3 --beta 6.0 --input /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg --render-mode both --slice4 auto --auto-slices 4 --output-dir /private/tmp/VisualizingLQCD-topological-config-review
 
-/Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_topological_density_config_movie.jl --nx 24 --ny 24 --nz 24 --nt 32 --nc 3 --beta 6.0 --input /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg --render-mode volume --camera-motion orbit --frame-mode sequence --nloops 1 --output-dir /private/tmp/VisualizingLQCD-topological-config-movie-review
+/Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_topological_density_config_movie.jl --nx 24 --ny 24 --nz 24 --nt 32 --nc 3 --beta 6.0 --input /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg --render-mode volume --camera-motion orbit --frame-mode sequence --nloops 2 --framerate 8 --figure-size 480 --show-render-progress true --output-dir /private/tmp/VisualizingLQCD-topological-config-movie-review
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -507,10 +507,17 @@ end
 @testset "Sample artifact contracts" begin
     root = dirname(@__DIR__)
     readme_text = read(joinpath(root, "README.md"), String)
+    topology_readme_text = read(joinpath(root, "scripts", "topology_fixtures", "README.md"),
+        String)
     @test occursin("$(SAMPLE_BASENAME).gif", readme_text)
     @test occursin("width=\"300\"", readme_text)
     @test occursin("`896` frames", readme_text)
     @test occursin("show_axis_labels=false", readme_text)
+    @test occursin("LEVEL_TARGET_TOPOLOGICAL_CHARGE_DENSITY", readme_text)
+    @test occursin("RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME", readme_text)
+    @test occursin("`abs(q)`", readme_text)
+    @test occursin("q0.940", topology_readme_text)
+    @test occursin("--show-render-progress true", topology_readme_text)
     @test isfile(joinpath(root, "$(SAMPLE_BASENAME).mp4"))
     @test isfile(joinpath(root, "$(SAMPLE_BASENAME).gif"))
     @test isfile(joinpath(root, "test", "$(SAMPLE_BASENAME).gif"))


### PR DESCRIPTION
Summary:
- Add a README section showing how to render topological charge density with LEVEL_TARGET_TOPOLOGICAL_CHARGE_DENSITY and RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME.
- Document the reviewed q0.940/q0.999 topological-volume baseline, signed palettes, local abs(q) coloring, Euclidean slice interpretation, and metadata sidecar.
- Update the topology fixture README with the accepted movie-review command and guidance for threshold overrides.
- Extend sample artifact tests so these topological-density docs do not disappear silently.

Validation:
- git diff --check
- /Users/akio/.juliaup/bin/julia --project=. test/runtests.jl

Notes:
- Documentation/test-only PR. No render output or package behavior changes.