### PR TITLE
[codex] Document topological sample reproduction

### DIFF
--- a/docs/codex/topological_density_sample_commands.md
+++ b/docs/codex/topological_density_sample_commands.md
@@ -1,0 +1,90 @@
+# Topological Density Sample Commands
+
+Last updated: 2026-05-11
+
+This memo records the reproducible command path for the reviewed
+topological-charge-density README sample. It is intentionally separate from
+`visualization_refactor_status.md` so it can be edited while PR #42 touches the
+main status memo.
+
+## Current Progress
+
+- User-facing visualization pipeline: about `85%`.
+- README/sample media path: about `90%`.
+- Topological charge-density physics-validation depth: about `70%`.
+
+The main remaining physics validation item is a true gauge-field instanton or
+SU(3)-embedded instanton check from the Gaugefields.jl-side work. The current
+VisualizingLQCD.jl path is already useful for real-configuration visual review,
+but it is not yet the final research-grade instanton calibration suite.
+
+## Reviewed README Sample
+
+- Input:
+  `/Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg`
+- Durable accepted artifact location:
+  `studio1:/Users/akio/VisualizingLQCD-review-artifacts/topological-readme-halfspeed-20260511`
+- Local review page used for acceptance:
+  `file:///private/tmp/VisualizingLQCD-topological-readme-halfspeed-remote-20260511/view.html`
+- Accepted visual-review item:
+  `no-axis / gif 300 half-speed`
+
+## Reproduction Command
+
+Run from the repository root:
+
+```sh
+/Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_topological_density_config_movie.jl --nx 24 --ny 24 --nz 24 --nt 32 --nc 3 --beta 6.0 --input /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg --output-name topological_density_noaxis_halfspeed.mp4 --render-mode volume --camera-motion orbit --frame-mode sequence --camera-orbit-turns 1 --nloops 4 --framerate 8 --figure-size 480 --show-axis-labels false --show-render-progress true --output-dir /private/tmp/VisualizingLQCD-topological-readme-sample
+```
+
+Expected metadata:
+
+- `level_target=topological_charge_density`
+- `render_style=topological_charge_volume`
+- `frame_mode=slice4_sequence`
+- `nloops=4`
+- `framerate=8`
+- `frame_count=128`
+- `duration_seconds=16.0`
+- `camera_orbit_turns=1`
+- `show_axis_labels=false`
+
+## Operating Notes
+
+- Do not rely on `/private/tmp` as the only artifact location. Copy the MP4,
+  metadata sidecar, GIF, review HTML, and command/log notes to durable storage
+  before asking for visual review.
+- Record the machine name. GLMakie rendering is still display/backend
+  dependent; `studio1` is the last known-good render machine for this sample.
+- Use still-review pages before long movie renders when tuning thresholds,
+  colors, or mesh smoothing.
+- Keep README media small. The accepted committed GIF is the `300 x 300`
+  derivative, not the larger 480 px review GIF.
+
+## Validation
+
+Current branch: `codex/topological-sample-docs`.
+
+```text
+/Users/akio/.juliaup/bin/julia --project=. -e 'include("scripts/topology_fixtures/render_topological_density_config_movie.jl"); @assert parse_bool("false", "--show-axis-labels") == false; @assert parse_bool("true", "--show-axis-labels") == true; println("movie helper syntax and parse smoke passed")'
+result: pass
+
+/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
+result: pass, 218 tests, render smoke skipped
+
+/Users/akio/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test()'
+result: pass, 218 tests, render smoke skipped
+
+git diff --check
+result: pass
+```
+
+## Next Steps
+
+1. Finish PR #42, which locks the tracked README sample metadata contract.
+2. Keep this command path as the canonical topological-density README sample
+   reproduction route.
+3. Next code-health work should separate renderer/I/O orchestration around
+   `create_animation` without changing rendered output.
+4. Resume true instanton validation once the Gaugefields.jl-side implementation
+   is ready.

--- a/scripts/topology_fixtures/README.md
+++ b/scripts/topology_fixtures/README.md
@@ -25,6 +25,8 @@ on a full GLMakie `record` loop.
 topological-density path, but writes one or more movies plus a review HTML page.
 It is a thin wrapper around `VisualizingLQCD.create_animation`, intended for
 small reviewed movie runs after the still-review page looks reasonable.
+Use `--show-axis-labels false` for README-style orbit movies; it keeps the grid
+and 3D box but avoids axis-label shimmer during rotation.
 
 For volume rendering, the current reviewed baseline uses a `q0.940` lower
 `|q|` body threshold and colors each sign by local `abs(q)`: positive charge is
@@ -63,3 +65,15 @@ Run from the repository root:
 
 /Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_topological_density_config_movie.jl --nx 24 --ny 24 --nz 24 --nt 32 --nc 3 --beta 6.0 --input /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg --render-mode volume --camera-motion orbit --frame-mode sequence --nloops 2 --framerate 8 --figure-size 480 --show-render-progress true --output-dir /private/tmp/VisualizingLQCD-topological-config-movie-review
 ```
+
+The accepted README sample can be reproduced from the same input configuration
+with the following reviewed settings:
+
+```sh
+/Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_topological_density_config_movie.jl --nx 24 --ny 24 --nz 24 --nt 32 --nc 3 --beta 6.0 --input /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg --output-name topological_density_noaxis_halfspeed.mp4 --render-mode volume --camera-motion orbit --frame-mode sequence --camera-orbit-turns 1 --nloops 4 --framerate 8 --figure-size 480 --show-axis-labels false --show-render-progress true --output-dir /private/tmp/VisualizingLQCD-topological-readme-sample
+```
+
+This produces `128` frames at `8` fps: all `32` Euclidean fourth-direction
+slices are shown four times while the camera completes one full turn. Keep the
+source MP4 and metadata sidecar in durable storage before making a user-review
+page or committing derived README media.

--- a/scripts/topology_fixtures/render_topological_density_config_movie.jl
+++ b/scripts/topology_fixtures/render_topological_density_config_movie.jl
@@ -136,6 +136,7 @@ function render_movie(mode, options)
         camera_motion=options.camera_motion,
         camera_orbit_turns=options.camera_orbit_turns,
         camera_orbit_seconds=options.camera_orbit_seconds,
+        show_axis_labels=options.show_axis_labels,
         show_render_progress=options.show_render_progress)
     return (
         label="$(String(mode)) movie",
@@ -154,6 +155,7 @@ function options_summary_text(options)
         "style_preset = $(String(options.style_preset))",
         "frame_mode = $(String(options.frame_mode))",
         "camera_motion = $(String(options.camera_motion))",
+        "show_axis_labels = $(options.show_axis_labels)",
     ), "\n")
 end
 
@@ -369,6 +371,8 @@ function main(args=ARGS)
             string(VisualizingLQCD.CURRENT_CAMERA_ORBIT_SECONDS))),
         cache_render_slices=parse_bool(arg_value(args, "cache-render-slices", "true"),
             "--cache-render-slices"),
+        show_axis_labels=parse_bool(arg_value(args, "show-axis-labels", "true"),
+            "--show-axis-labels"),
         show_render_progress=parse_bool(arg_value(args, "show-render-progress", "true"),
             "--show-render-progress"),
     )


### PR DESCRIPTION
## Summary

- add `--show-axis-labels` to the topological-density config movie helper so README-style no-axis orbit movies are reproducible from the helper
- document the accepted topological README sample command in `scripts/topology_fixtures/README.md`
- add a dedicated memo for the sample command path, current progress estimate, concerns, and next steps

## Notes

PR #42 is still open at the time this branch was created. This branch avoids the main status memo and test file so it can stay low-conflict while #42 is reviewed/merged.

Current progress estimate recorded in the memo:

- user-facing visualization pipeline: about 85%
- README/sample media path: about 90%
- topological charge-density physics-validation depth: about 70%

## Tests

- `/Users/akio/.juliaup/bin/julia --project=. -e 'include("scripts/topology_fixtures/render_topological_density_config_movie.jl"); @assert parse_bool("false", "--show-axis-labels") == false; @assert parse_bool("true", "--show-axis-labels") == true; println("movie helper syntax and parse smoke passed")'`
- `/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl`
- `/Users/akio/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test()'`
- `git diff --check`
