### PR TITLE
[codex] Extract mesh render helpers

### DIFF
--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,8 +4,71 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-11 after starting README sample contract checks and
-the current roadmap snapshot.
+Last updated on 2026-05-11 after starting mesh render helper extraction.
+
+## Active note: 2026-05-11 mesh render helper extraction
+
+- Machine: `Akios-MacBook-Air.local`.
+- Workdir:
+
+```text
+/Users/akio/repository/VisualizingLQCD_v2/VisualizingLQCD.jl
+```
+
+- Branch: `codex/mesh-render-helpers`.
+- Starting point: PR #42 and PR #43 were merged into `main`.
+- Goal:
+  - start the renderer separation work with a small behavior-preserving PR;
+  - move mesh renderer selection, geometry construction, and plot dispatch out of
+    the `create_animation` draw loop;
+  - keep existing visual output, mesh cache behavior, and metadata contracts
+    unchanged.
+- Scope:
+  - `mesh_renderer_kind` maps setups without an explicit `mesh_renderer` to the
+    existing action-density blob path;
+  - `mesh_geometry_for_slice` selects action-density blob vs topological
+    charge-density volume geometry;
+  - `mesh_plot_geometry!` dispatches the already-built geometry to the matching
+    plot helper.
+- Current progress estimate:
+  - visualization refactor/user-facing pipeline: about `86%`;
+  - README/sample media path: about `90%`;
+  - physics-validation depth for topological charge density: about `70%`.
+- Done before this PR:
+  - magic-number defaults, metadata sidecars, Euclidean-slice framing, render
+    progress, camera orbit, mesh cache, action-density visual default, README
+    sample replacement, and README sample contract checks;
+  - topological charge-density observable, signed/volume renderers, style
+    tuning, real-configuration visual review, absolute-magnitude coloring, and
+    README topological sample;
+  - cold topological density, scalar SU(2) instanton-like fixtures, and SU(2)
+    Gaugefields.Oneinstanton scalar-Q oracle coverage.
+- Main concerns:
+  - topological density is visually useful, but research-grade validation still
+    depends on separate true instanton gauge-field work;
+  - GLMakie rendering is still machine/display dependent, so durable artifact
+    paths and machine names must continue to be recorded;
+  - `create_animation` is still large after this PR; I/O separation and
+    observable orchestration remain future work.
+- Next likely PRs, in order:
+  1. Continue renderer separation by extracting contour renderer dispatch.
+  2. Separate render metadata assembly from movie recording.
+  3. Move configuration-generation/sample commands into clearer user-facing
+     examples.
+  4. True instanton/SU(3)-embedded validation once Gaugefields.jl-side work is
+     ready.
+- Validation:
+
+```text
+/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
+result: pass, 233 tests, render smoke skipped
+
+/Users/akio/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test()'
+result: pass, 233 tests, render smoke skipped
+
+git diff --check
+result: pass
+```
 
 ## Active note: 2026-05-11 README sample contract checks and roadmap snapshot
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -179,6 +179,33 @@ function topological_charge_display_level_setup(density_t;
     )
 end
 
+function mesh_renderer_kind(setup)
+    if hasproperty(setup, :mesh_renderer)
+        return setup.mesh_renderer
+    end
+    return :action_density_blob
+end
+
+function mesh_geometry_for_slice(data, setup; a, lattice_size)
+    renderer = mesh_renderer_kind(setup)
+    if renderer == :topological_charge_volume
+        return topological_charge_volume_geometry(data, setup; a=a, lattice_size=lattice_size)
+    elseif renderer == :action_density_blob
+        return action_density_blob_geometry(data, setup; a=a, lattice_size=lattice_size)
+    end
+    throw(ArgumentError("unsupported mesh renderer: $renderer"))
+end
+
+function mesh_plot_geometry!(ax, geometry, setup)
+    renderer = mesh_renderer_kind(setup)
+    if renderer == :topological_charge_volume
+        return topological_charge_volume_plot!(ax, geometry)
+    elseif renderer == :action_density_blob
+        return action_density_blob_plot!(ax, geometry)
+    end
+    throw(ArgumentError("unsupported mesh renderer: $renderer"))
+end
+
 function create_animation(NX, NY, NZ, NT, NC, videoname;
     beta=CURRENT_BETA_ANIMATION_DEFAULT,
     flow_steps_in=CURRENT_FLOW_STEPS_ANIMATION_DEFAULT,
@@ -402,28 +429,16 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
         ax.title = movie_title
 
         if display_setup.render_kind == :mesh
-            if hasproperty(display_setup, :mesh_renderer) &&
-               display_setup.mesh_renderer == :topological_charge_volume
-                if cache_active
-                    geometry = get!(mesh_cache, slice4) do
-                        topological_charge_volume_geometry(plaqs, display_setup;
-                            a=a, lattice_size=(NX, NY, NZ))
-                    end
-                    plot_obj[], _ = topological_charge_volume_plot!(ax, geometry)
-                else
-                    geometry = topological_charge_volume_geometry(plaqs, display_setup;
-                        a=a, lattice_size=(NX, NY, NZ))
-                    plot_obj[], _ = topological_charge_volume_plot!(ax, geometry)
-                end
-            elseif cache_active
+            if cache_active
                 geometry = get!(mesh_cache, slice4) do
-                    action_density_blob_geometry(plaqs, display_setup;
+                    mesh_geometry_for_slice(plaqs, display_setup;
                         a=a, lattice_size=(NX, NY, NZ))
                 end
-                plot_obj[], _ = action_density_blob_plot!(ax, geometry)
+                plot_obj[], _ = mesh_plot_geometry!(ax, geometry, display_setup)
             else
-                plot_obj[], _ = action_density_blob_plot!(ax, plaqs, display_setup;
+                geometry = mesh_geometry_for_slice(plaqs, display_setup;
                     a=a, lattice_size=(NX, NY, NZ))
+                plot_obj[], _ = mesh_plot_geometry!(ax, geometry, display_setup)
             end
         else
             plot_obj[] = contour_plot_group!(plaqs, levels)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -344,6 +344,16 @@ end
     @test action_geometry.info.vertices > 0
     @test action_geometry.info.faces > 0
     @test length(action_geometry.colors) == action_geometry.info.vertices
+    helper_action_geometry = VisualizingLQCD.mesh_geometry_for_slice(
+        fill(action_setup.body_level + 1, 2, 2, 2), action_setup;
+        a=1.0, lattice_size=(2, 2, 2))
+    @test VisualizingLQCD.mesh_renderer_kind(action_setup) == :action_density_blob
+    @test helper_action_geometry.info.vertices == action_geometry.info.vertices
+    @test helper_action_geometry.info.faces == action_geometry.info.faces
+    unsupported_mesh_setup = merge(action_setup, (mesh_renderer=:unsupported,))
+    @test_throws ArgumentError VisualizingLQCD.mesh_geometry_for_slice(
+        fill(action_setup.body_level + 1, 2, 2, 2), unsupported_mesh_setup;
+        a=1.0, lattice_size=(2, 2, 2))
 
     topological_setup = VisualizingLQCD.topological_charge_display_level_setup(
         reshape([-4.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0], 2, 2, 2, 1);
@@ -440,6 +450,14 @@ end
     @test topological_volume_geometry.negative !== nothing
     @test topological_volume_geometry.info["positive_info"].vertices > 0
     @test topological_volume_geometry.info["negative_info"].vertices > 0
+    helper_topological_volume_geometry = VisualizingLQCD.mesh_geometry_for_slice(
+        volume_slice, topological_volume_setup; a=1.0, lattice_size=(3, 3, 3))
+    @test VisualizingLQCD.mesh_renderer_kind(topological_volume_setup) ==
+          :topological_charge_volume
+    @test helper_topological_volume_geometry.info["positive_info"].vertices ==
+          topological_volume_geometry.info["positive_info"].vertices
+    @test helper_topological_volume_geometry.info["negative_info"].vertices ==
+          topological_volume_geometry.info["negative_info"].vertices
     gradient_slice = zeros(6, 3, 3)
     gradient_slice[2, :, :] .= 1.2
     gradient_slice[3, :, :] .= 2.0


### PR DESCRIPTION
## Summary
- Extract mesh renderer selection, geometry construction, and plot dispatch from the `create_animation` draw loop.
- Preserve the existing action-density blob fallback for setups without `mesh_renderer`.
- Add contract tests for action-density and topological charge-density mesh helper dispatch, plus the current roadmap/status memo.

## Validation
- `/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl` pass, 233 tests, render smoke skipped
- `/Users/akio/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test()'` pass, 233 tests, render smoke skipped
- `git diff --check` pass