### PR TITLE
[codex] Split create_animation helpers

### DIFF
--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,7 +4,75 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-11 after starting mesh render helper extraction.
+Last updated on 2026-05-11 after starting create_animation helper splitting.
+
+## Active note: 2026-05-11 create_animation helper splitting
+
+- Machine: `Akios-MacBook-Air.local`.
+- Workdir:
+
+```text
+/Users/akio/repository/VisualizingLQCD_v2/VisualizingLQCD.jl
+```
+
+- Branch: `codex/split-create-animation-helpers`.
+- Starting point: PR #44 was merged into `main`.
+- Goal:
+  - continue the renderer/orchestration separation with another small PR;
+  - split frame planning, axis tick/keyword construction, and the Makie record
+    loop out of `create_animation`;
+  - keep rendered output and metadata contracts unchanged.
+- Scope:
+  - `animation_render_plan` centralizes framerate, nloop, frame-mode, figure-size,
+    progress, axis-label, and mesh-cache validation;
+  - `animation_axis_tick_spec` and `animation_axis_kwargs` preserve the existing
+    tick-label thinning, axis-label hiding, theme colors, and camera keyword
+    behavior;
+  - `record_animation_frames!` keeps the current record loop semantics while
+    making the fourth-direction frame update logic easier to isolate later.
+- Current progress estimate:
+  - visualization refactor/user-facing pipeline: about `87%`;
+  - README/sample media path: about `90%`;
+  - physics-validation depth for topological charge density: about `70%`.
+- Main concerns:
+  - this PR makes `create_animation` smaller, but observable selection and I/O are
+    still inside it;
+  - GLMakie render behavior remains machine/display dependent, so visual-review
+    artifacts still need durable paths and machine names;
+  - true instanton/SU(3)-embedded validation remains outside this repo's current
+    merged state.
+- Next likely PRs, in order:
+  1. Extract contour draw dispatch and plot-object deletion into renderer helpers.
+  2. Separate observable/display setup from gauge-field I/O.
+  3. Separate metadata assembly from movie recording.
+  4. True instanton/SU(3)-embedded validation once Gaugefields.jl-side work is
+     ready.
+- Validation:
+
+```text
+/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
+result: pass, 253 tests, render smoke skipped
+
+/Users/akio/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test()'
+result: blocked before tests by Julia Pkg resolution:
+        Qt6Base_jll 6.10.2+1 is in Manifest.toml, but the current registry
+        exposes 6.10.2+2 and not 6.10.2+1. No package files were changed.
+
+/Users/akio/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test(; allow_reresolve=false)'
+result: same Pkg resolution block
+
+JULIA_PKG_OFFLINE=true /Users/akio/.juliaup/bin/julia --project=. \
+  -e 'using Pkg; Pkg.test(; allow_reresolve=false)'
+result: same Pkg resolution block
+
+/Users/akio/.juliaup/bin/julia --project=. -e 'using VisualizingLQCD; ...'
+result: pass, direct create_animation smoke wrote:
+        /private/tmp/VisualizingLQCD-split-create-smoke/smoke.mp4
+        /private/tmp/VisualizingLQCD-split-create-smoke/smoke.metadata.json
+
+git diff --check
+result: pass
+```
 
 ## Active note: 2026-05-11 mesh render helper extraction
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -206,6 +206,129 @@ function mesh_plot_geometry!(ax, geometry, setup)
     throw(ArgumentError("unsupported mesh renderer: $renderer"))
 end
 
+function animation_render_plan(NT::Integer, display_setup, camera;
+    framerate=nothing,
+    nloops=nothing,
+    frame_mode=nothing,
+    fixed_slice4=CURRENT_FIXED_SLICE4,
+    slice_hold_frames=CURRENT_SLICE_HOLD_FRAMES,
+    cache_render_slices=CURRENT_CACHE_RENDER_SLICES,
+    figure_size=CURRENT_FIGURE_SIZE,
+    show_render_progress=CURRENT_SHOW_RENDER_PROGRESS,
+    show_axis_labels=CURRENT_SHOW_AXIS_LABELS)
+
+    effective_framerate = framerate !== nothing ? framerate :
+                          (camera.motion == CAMERA_MOTION_ORBIT ?
+                           CURRENT_CAMERA_ORBIT_FRAMERATE : CURRENT_MOVIE_FRAMERATE)
+    effective_framerate > 0 || throw(ArgumentError("framerate should be positive"))
+    effective_frame_mode = frame_mode === nothing ? default_frame_mode(camera.motion) :
+                           validate_frame_mode(frame_mode)
+    effective_slice_hold_frames = validate_slice_hold_frames(slice_hold_frames)
+    effective_nloops = nloops === nothing ?
+                       default_movie_nloops(NT, effective_framerate, camera;
+                           frame_mode=effective_frame_mode,
+                           slice_hold_frames=effective_slice_hold_frames) : nloops
+    effective_nloops isa Integer || throw(ArgumentError("nloops should be an integer"))
+    effective_nloops > 0 || throw(ArgumentError("nloops should be positive"))
+    slice4_for_frame(1, NT; frame_mode=effective_frame_mode, fixed_slice4=fixed_slice4,
+        slice_hold_frames=effective_slice_hold_frames)
+    cache_render_slices isa Bool || throw(ArgumentError("cache_render_slices should be Bool"))
+    effective_figure_size = validate_figure_size(figure_size)
+    effective_show_render_progress = validate_show_render_progress(show_render_progress)
+    effective_show_axis_labels = validate_show_axis_labels(show_axis_labels)
+    cache_active = cache_render_slices && display_setup.render_kind == :mesh
+    total_frames = total_movie_frames(NT, effective_nloops;
+        frame_mode=effective_frame_mode, slice_hold_frames=effective_slice_hold_frames)
+
+    return (
+        framerate=effective_framerate,
+        nloops=effective_nloops,
+        frame_mode=effective_frame_mode,
+        fixed_slice4=fixed_slice4,
+        slice_hold_frames=effective_slice_hold_frames,
+        figure_size=effective_figure_size,
+        show_render_progress=effective_show_render_progress,
+        show_axis_labels=effective_show_axis_labels,
+        cache_active=cache_active,
+        total_frames=total_frames,
+        fixed_frame=effective_frame_mode == FRAME_MODE_FIXED,
+    )
+end
+
+function animation_axis_tick_spec(N::Integer, a::Real; show_axis_labels::Bool)
+    positions = range(0, stop=a * N, length=N)
+    labels = [string(round(x, digits=CURRENT_TICK_DIGITS)) for x in positions]
+    for i in 1:CURRENT_TICK_STRIDE:length(labels)
+        labels[i] = ""
+    end
+    show_axis_labels || fill!(labels, "")
+    return (positions=positions, labels=labels)
+end
+
+function animation_axis_kwargs(display_setup, theme_settings, camera;
+    a, lattice_size, movie_title, show_axis_labels::Bool)
+
+    NX, NY, NZ = lattice_size
+    x_ticks = animation_axis_tick_spec(NX, a; show_axis_labels=show_axis_labels)
+    y_ticks = animation_axis_tick_spec(NY, a; show_axis_labels=show_axis_labels)
+    z_ticks = animation_axis_tick_spec(NZ, a; show_axis_labels=show_axis_labels)
+    axis_aspect = display_setup.render_kind == :mesh ? :data : CURRENT_ASPECT
+    axis_kwargs = Dict{Symbol,Any}(
+        :xlabel => show_axis_labels ? myxlabel : "",
+        :ylabel => show_axis_labels ? myylabel : "",
+        :zlabel => show_axis_labels ? myzlabel : "",
+        :title => movie_title,
+        :xticks => (x_ticks.positions, x_ticks.labels),
+        :yticks => (y_ticks.positions, y_ticks.labels),
+        :zticks => (z_ticks.positions, z_ticks.labels),
+        :aspect => axis_aspect,
+        :backgroundcolor => theme_settings.axis_background,
+        :xlabelcolor => theme_settings.text_color,
+        :ylabelcolor => theme_settings.text_color,
+        :zlabelcolor => theme_settings.text_color,
+        :titlecolor => theme_settings.text_color,
+        :xticklabelcolor => theme_settings.text_color,
+        :yticklabelcolor => theme_settings.text_color,
+        :zticklabelcolor => theme_settings.text_color,
+        :xtickcolor => theme_settings.text_color,
+        :ytickcolor => theme_settings.text_color,
+        :ztickcolor => theme_settings.text_color,
+        :xgridcolor => theme_settings.grid_color,
+        :ygridcolor => theme_settings.grid_color,
+        :zgridcolor => theme_settings.grid_color,
+    )
+    camera.azimuth === nothing || (axis_kwargs[:azimuth] = camera.azimuth)
+    camera.elevation === nothing || (axis_kwargs[:elevation] = camera.elevation)
+    camera.perspectiveness === nothing ||
+        (axis_kwargs[:perspectiveness] = camera.perspectiveness)
+    camera.viewmode === nothing || (axis_kwargs[:viewmode] = camera.viewmode)
+    return axis_kwargs
+end
+
+function record_animation_frames!(fig, ax, videoname, NT, camera, draw_slice!,
+    current_slice4, render_plan)
+
+    render_plan.fixed_frame && draw_slice!(render_plan.fixed_slice4)
+    render_progress = render_plan.show_render_progress ?
+                      Progress(render_plan.total_frames;
+                          desc=CURRENT_RENDER_PROGRESS_DESCRIPTION,
+                          showspeed=CURRENT_RENDER_PROGRESS_SHOWSPEED) :
+                      nothing
+    record(fig, videoname, 1:render_plan.total_frames;
+        framerate=render_plan.framerate) do i
+        apply_camera_settings!(ax, camera, i, render_plan.total_frames)
+        if !render_plan.fixed_frame
+            slice4 = slice4_for_frame(i, NT;
+                frame_mode=render_plan.frame_mode,
+                fixed_slice4=render_plan.fixed_slice4,
+                slice_hold_frames=render_plan.slice_hold_frames)
+            current_slice4[] == slice4 || draw_slice!(slice4)
+        end
+        render_progress === nothing || next!(render_progress)
+    end
+    return nothing
+end
+
 function create_animation(NX, NY, NZ, NT, NC, videoname;
     beta=CURRENT_BETA_ANIMATION_DEFAULT,
     flow_steps_in=CURRENT_FLOW_STEPS_ANIMATION_DEFAULT,
@@ -296,26 +419,24 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
         camera_orbit_seconds=camera_orbit_seconds,
         camera_perspectiveness=camera_perspectiveness,
         camera_viewmode=camera_viewmode)
-    effective_framerate = framerate !== nothing ? framerate :
-                          (camera.motion == CAMERA_MOTION_ORBIT ?
-                           CURRENT_CAMERA_ORBIT_FRAMERATE : CURRENT_MOVIE_FRAMERATE)
-    effective_framerate > 0 || throw(ArgumentError("framerate should be positive"))
-    effective_frame_mode = frame_mode === nothing ? default_frame_mode(camera.motion) :
-                           validate_frame_mode(frame_mode)
-    effective_slice_hold_frames = validate_slice_hold_frames(slice_hold_frames)
-    effective_nloops = nloops === nothing ?
-                       default_movie_nloops(NT, effective_framerate, camera;
-                           frame_mode=effective_frame_mode,
-                           slice_hold_frames=effective_slice_hold_frames) : nloops
-    effective_nloops isa Integer || throw(ArgumentError("nloops should be an integer"))
-    effective_nloops > 0 || throw(ArgumentError("nloops should be positive"))
-    slice4_for_frame(1, NT; frame_mode=effective_frame_mode, fixed_slice4=fixed_slice4,
-        slice_hold_frames=effective_slice_hold_frames)
-    cache_render_slices isa Bool || throw(ArgumentError("cache_render_slices should be Bool"))
-    effective_figure_size = validate_figure_size(figure_size)
-    effective_show_render_progress = validate_show_render_progress(show_render_progress)
-    effective_show_axis_labels = validate_show_axis_labels(show_axis_labels)
-    cache_active = cache_render_slices && display_setup.render_kind == :mesh
+    render_plan = animation_render_plan(NT, display_setup, camera;
+        framerate=framerate,
+        nloops=nloops,
+        frame_mode=frame_mode,
+        fixed_slice4=fixed_slice4,
+        slice_hold_frames=slice_hold_frames,
+        cache_render_slices=cache_render_slices,
+        figure_size=figure_size,
+        show_render_progress=show_render_progress,
+        show_axis_labels=show_axis_labels)
+    effective_framerate = render_plan.framerate
+    effective_frame_mode = render_plan.frame_mode
+    effective_slice_hold_frames = render_plan.slice_hold_frames
+    effective_nloops = render_plan.nloops
+    effective_figure_size = render_plan.figure_size
+    effective_show_render_progress = render_plan.show_render_progress
+    effective_show_axis_labels = render_plan.show_axis_labels
+    cache_active = render_plan.cache_active
 
     #= To check iso-level, please use here
     hist_p = histogram(vec(plaqs_t))
@@ -331,62 +452,11 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
     fig = Figure(
         size=effective_figure_size,
         backgroundcolor=theme_settings.figure_background)
-    # label setting.
-    x_positions = range(0, stop=a * NX, length=NX)
-    x_labels = [string(round(x, digits=CURRENT_TICK_DIGITS)) for x in x_positions]
-
-    y_positions = range(0, stop=a * NY, length=NY)
-    y_labels = [string(round(y, digits=CURRENT_TICK_DIGITS)) for y in y_positions]
-
-    z_positions = range(0, stop=a * NZ, length=NZ)
-    z_labels = [string(round(z, digits=CURRENT_TICK_DIGITS)) for z in z_positions]
-
-    for i in 1:CURRENT_TICK_STRIDE:length(x_labels)
-        x_labels[i] = ""
-    end
-    for i in 1:CURRENT_TICK_STRIDE:length(y_labels)
-        y_labels[i] = ""
-    end
-    for i in 1:CURRENT_TICK_STRIDE:length(z_labels)
-        z_labels[i] = ""
-    end
-
-    if !effective_show_axis_labels
-        fill!(x_labels, "")
-        fill!(y_labels, "")
-        fill!(z_labels, "")
-    end
-
-    axis_aspect = display_setup.render_kind == :mesh ? :data : CURRENT_ASPECT
-    axis_kwargs = Dict{Symbol,Any}(
-        :xlabel => effective_show_axis_labels ? myxlabel : "",
-        :ylabel => effective_show_axis_labels ? myylabel : "",
-        :zlabel => effective_show_axis_labels ? myzlabel : "",
-        :title => movie_title,
-        :xticks => (x_positions, x_labels),
-        :yticks => (y_positions, y_labels),
-        :zticks => (z_positions, z_labels),
-        :aspect => axis_aspect,
-        :backgroundcolor => theme_settings.axis_background,
-        :xlabelcolor => theme_settings.text_color,
-        :ylabelcolor => theme_settings.text_color,
-        :zlabelcolor => theme_settings.text_color,
-        :titlecolor => theme_settings.text_color,
-        :xticklabelcolor => theme_settings.text_color,
-        :yticklabelcolor => theme_settings.text_color,
-        :zticklabelcolor => theme_settings.text_color,
-        :xtickcolor => theme_settings.text_color,
-        :ytickcolor => theme_settings.text_color,
-        :ztickcolor => theme_settings.text_color,
-        :xgridcolor => theme_settings.grid_color,
-        :ygridcolor => theme_settings.grid_color,
-        :zgridcolor => theme_settings.grid_color,
-    )
-    camera.azimuth === nothing || (axis_kwargs[:azimuth] = camera.azimuth)
-    camera.elevation === nothing || (axis_kwargs[:elevation] = camera.elevation)
-    camera.perspectiveness === nothing ||
-        (axis_kwargs[:perspectiveness] = camera.perspectiveness)
-    camera.viewmode === nothing || (axis_kwargs[:viewmode] = camera.viewmode)
+    axis_kwargs = animation_axis_kwargs(display_setup, theme_settings, camera;
+        a=a,
+        lattice_size=(NX, NY, NZ),
+        movie_title=movie_title,
+        show_axis_labels=effective_show_axis_labels)
 
     # Make Axis3
     ax = Axis3(fig[1, 1]; axis_kwargs...)
@@ -448,25 +518,8 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
         return nothing
     end
 
-    t_end = total_movie_frames(NT, effective_nloops;
-        frame_mode=effective_frame_mode, slice_hold_frames=effective_slice_hold_frames)
-    fixed_frame = effective_frame_mode == FRAME_MODE_FIXED
-    fixed_frame && draw_slice!(fixed_slice4)
-    render_progress = effective_show_render_progress ?
-                      Progress(t_end;
-                          desc=CURRENT_RENDER_PROGRESS_DESCRIPTION,
-                          showspeed=CURRENT_RENDER_PROGRESS_SHOWSPEED) :
-                      nothing
-    record(fig, videoname, 1:t_end; framerate=effective_framerate) do i
-        apply_camera_settings!(ax, camera, i, t_end)
-        if !fixed_frame
-            slice4 = slice4_for_frame(i, NT;
-                frame_mode=effective_frame_mode, fixed_slice4=fixed_slice4,
-                slice_hold_frames=effective_slice_hold_frames)
-            current_slice4[] == slice4 || draw_slice!(slice4)
-        end
-        render_progress === nothing || next!(render_progress)
-    end
+    record_animation_frames!(fig, ax, videoname, NT, camera, draw_slice!, current_slice4,
+        render_plan)
 
     metadata = animation_metadata(
         videoname=videoname,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,6 +136,36 @@ end
           VisualizingLQCD.FRAME_MODE_SEQUENCE
     @test VisualizingLQCD.default_frame_mode(orbit_camera.motion) ==
           VisualizingLQCD.FRAME_MODE_FIXED
+    sequence_plan = VisualizingLQCD.animation_render_plan(
+        4, (render_kind=:contour,), static_camera;
+        framerate=8,
+        nloops=2,
+        frame_mode=VisualizingLQCD.FRAME_MODE_SEQUENCE,
+        slice_hold_frames=2,
+        cache_render_slices=true,
+        figure_size=(320, 240),
+        show_render_progress=false,
+        show_axis_labels=false)
+    @test sequence_plan.framerate == 8
+    @test sequence_plan.total_frames == 16
+    @test sequence_plan.cache_active == false
+    @test sequence_plan.figure_size == (320, 240)
+    @test sequence_plan.show_axis_labels == false
+    mesh_fixed_plan = VisualizingLQCD.animation_render_plan(
+        4, (render_kind=:mesh,), orbit_camera;
+        nloops=2,
+        frame_mode=VisualizingLQCD.FRAME_MODE_FIXED,
+        fixed_slice4=2,
+        cache_render_slices=true,
+        show_render_progress=false)
+    @test mesh_fixed_plan.framerate == VisualizingLQCD.CURRENT_CAMERA_ORBIT_FRAMERATE
+    @test mesh_fixed_plan.total_frames == 8
+    @test mesh_fixed_plan.cache_active
+    @test mesh_fixed_plan.fixed_frame
+    @test_throws ArgumentError VisualizingLQCD.animation_render_plan(
+        4, (render_kind=:mesh,), static_camera; nloops=1.5)
+    @test_throws ArgumentError VisualizingLQCD.animation_render_plan(
+        4, (render_kind=:mesh,), static_camera; cache_render_slices=:yes)
     @test VisualizingLQCD.camera_motion_metadata(orbit_camera)["camera_motion"] == "orbit"
     @test VisualizingLQCD.camera_motion_metadata(orbit_camera)["orbit_seconds"] ≈ 640 / 14
 
@@ -321,6 +351,30 @@ end
     @test action_setup.render_style_info["render_style"] == "action_density_blob"
     @test action_setup.render_style_info["color_quantiles"] ==
           collect(VisualizingLQCD.CURRENT_ACTION_DENSITY_COLOR_QUANTILES)
+    visible_ticks = VisualizingLQCD.animation_axis_tick_spec(4, 0.1;
+        show_axis_labels=true)
+    @test collect(visible_ticks.positions) ≈ collect(range(0, stop=0.4, length=4))
+    @test visible_ticks.labels[1] == ""
+    @test visible_ticks.labels[2] != ""
+    hidden_ticks = VisualizingLQCD.animation_axis_tick_spec(4, 0.1;
+        show_axis_labels=false)
+    @test all(==(""), hidden_ticks.labels)
+    axis_camera = VisualizingLQCD.camera_settings(:mesh;
+        camera_azimuth=0.0,
+        camera_elevation=0.5)
+    axis_kwargs = VisualizingLQCD.animation_axis_kwargs(
+        action_setup,
+        VisualizingLQCD.render_theme_settings(VisualizingLQCD.RENDER_THEME_DARK),
+        axis_camera;
+        a=0.1,
+        lattice_size=(4, 4, 4),
+        movie_title="test title",
+        show_axis_labels=false)
+    @test axis_kwargs[:aspect] == :data
+    @test axis_kwargs[:xlabel] == ""
+    @test all(==(""), axis_kwargs[:xticks][2])
+    @test axis_kwargs[:azimuth] == 0.0
+    @test axis_kwargs[:elevation] == 0.5
     @test VisualizingLQCD.action_density_blob_color(0.5; qmin=0.0, qmax=1.0) isa
           VisualizingLQCD.Vec3f
     positive_low_color = VisualizingLQCD.topological_charge_volume_magnitude_color(


### PR DESCRIPTION
## Summary
- Split frame planning, axis tick/keyword construction, and the Makie record loop out of `create_animation`.
- Preserve existing rendered-output behavior: tick thinning, axis-label hiding, theme/camera kwargs, frame/slice update logic, progress handling, and mesh cache selection are kept as-is.
- Add contract tests for the new render-plan and axis helper behavior, and update the refactor status memo.

## Validation
- `/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl` pass, 253 tests, render smoke skipped
- Direct `create_animation` smoke pass, wrote `/private/tmp/VisualizingLQCD-split-create-smoke/smoke.mp4` and metadata sidecar
- `git diff --check` pass

## Note
- `Pkg.test()` is currently blocked before tests by Julia Pkg resolution for the existing `Manifest.toml`: `Qt6Base_jll 6.10.2+1` is pinned in the manifest, while the current registry exposes `6.10.2+2` and not `6.10.2+1`. I did not change `Project.toml` or `Manifest.toml`.