### PR TITLE
[codex] Extract draw helpers

### DIFF
--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,7 +4,69 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-11 after starting create_animation helper splitting.
+Last updated on 2026-05-11 after starting draw helper extraction.
+
+## Active note: 2026-05-11 draw helper extraction
+
+- Machine: `Akios-MacBook-Air.local`.
+- Workdir:
+
+```text
+/Users/akio/repository/VisualizingLQCD_v2/VisualizingLQCD.jl
+```
+
+- Branch: `codex/extract-draw-helpers`.
+- Starting point: PR #45 was merged into `main`.
+- Goal:
+  - continue shrinking `create_animation` without changing rendered output;
+  - move plot deletion, contour plot grouping, mesh-cache geometry retrieval, and
+    per-slice plot dispatch into helpers;
+  - keep observable selection, gauge-field I/O, metadata assembly, and actual
+    GLMakie style behavior unchanged for this PR.
+- Scope:
+  - `delete_plot_obj!` deletes `nothing`, a single plot object, or a vector of
+    plot objects through the provided axis;
+  - `contour_plot_group!` owns the existing contour-spec loop;
+  - `mesh_geometry_for_render_slice` centralizes optional slice-keyed mesh cache
+    usage;
+  - `plot_animation_slice!` selects mesh vs contour plotting for one
+    fourth-direction slice.
+- Current progress estimate:
+  - visualization refactor/user-facing pipeline: about `88%`;
+  - README/sample media path: about `90%`;
+  - physics-validation depth for topological charge density: about `70%`.
+- Main concerns:
+  - `create_animation` is now smaller, but it still owns gauge-field loading,
+    observable selection, figure setup, and metadata assembly;
+  - GLMakie behavior still needs smoke/visual checks after helper movement;
+  - `Pkg.test()` is known to be blocked by the existing `Qt6Base_jll` manifest vs
+    registry mismatch until the package environment is refreshed deliberately.
+- Next likely PRs, in order:
+  1. Separate observable/display setup from gauge-field I/O.
+  2. Separate metadata assembly from movie recording.
+  3. Clean up user-facing example command structure.
+  4. True instanton/SU(3)-embedded validation once Gaugefields.jl-side work is
+     ready.
+- Validation:
+
+```text
+/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
+result: pass, 262 tests, render smoke skipped
+
+/Users/akio/.juliaup/bin/julia --project=. -e 'using VisualizingLQCD; ...'
+result: pass, direct create_animation smoke wrote:
+        /private/tmp/VisualizingLQCD-draw-helpers-smoke/smoke.mp4
+        /private/tmp/VisualizingLQCD-draw-helpers-smoke/smoke.metadata.json
+        metadata confirmed frame_count=16 and cached_slice_count=16
+
+git diff --check
+result: pass
+
+Pkg.test note:
+        not repeated on this branch; PR #45 already recorded that Pkg.test is
+        blocked before tests by the existing Qt6Base_jll 6.10.2+1 manifest vs
+        registry mismatch. This PR does not modify Project.toml or Manifest.toml.
+```
 
 ## Active note: 2026-05-11 create_animation helper splitting
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -196,6 +196,19 @@ function mesh_geometry_for_slice(data, setup; a, lattice_size)
     throw(ArgumentError("unsupported mesh renderer: $renderer"))
 end
 
+function mesh_geometry_for_render_slice(data, setup; a, lattice_size, mesh_cache=nothing,
+    slice4=nothing)
+
+    if mesh_cache === nothing
+        return mesh_geometry_for_slice(data, setup; a=a, lattice_size=lattice_size)
+    end
+    slice4 === nothing &&
+        throw(ArgumentError("slice4 is required when mesh_cache is provided"))
+    return get!(mesh_cache, slice4) do
+        mesh_geometry_for_slice(data, setup; a=a, lattice_size=lattice_size)
+    end
+end
+
 function mesh_plot_geometry!(ax, geometry, setup)
     renderer = mesh_renderer_kind(setup)
     if renderer == :topological_charge_volume
@@ -204,6 +217,43 @@ function mesh_plot_geometry!(ax, geometry, setup)
         return action_density_blob_plot!(ax, geometry)
     end
     throw(ArgumentError("unsupported mesh renderer: $renderer"))
+end
+
+function delete_plot_obj!(ax, obj)
+    obj === nothing && return nothing
+    if obj isa AbstractVector
+        for item in obj
+            delete!(ax, item)
+        end
+    else
+        delete!(ax, obj)
+    end
+    return nothing
+end
+
+function contour_plot_group!(ax, data, group_levels, contour_style;
+    x_physical, y_physical, z_physical)
+
+    objects = Any[]
+    for spec in contour_plot_specs(contour_style, group_levels)
+        contour_kwargs = contour_plot_kwargs(spec.style, spec.levels)
+        push!(objects, GLMakie.contour!(
+            ax, x_physical, y_physical, z_physical, data; contour_kwargs...))
+    end
+    return objects
+end
+
+function plot_animation_slice!(ax, data, display_setup, levels; a, lattice_size,
+    x_physical, y_physical, z_physical, mesh_cache=nothing, slice4=nothing)
+
+    if display_setup.render_kind == :mesh
+        geometry = mesh_geometry_for_render_slice(data, display_setup;
+            a=a, lattice_size=lattice_size, mesh_cache=mesh_cache, slice4=slice4)
+        plot_obj, _ = mesh_plot_geometry!(ax, geometry, display_setup)
+        return plot_obj
+    end
+    return contour_plot_group!(ax, data, levels, display_setup.contour_style;
+        x_physical=x_physical, y_physical=y_physical, z_physical=z_physical)
 end
 
 function animation_render_plan(NT::Integer, display_setup, camera;
@@ -465,54 +515,27 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
     plot_obj = Ref{Any}(nothing)
     current_slice4 = Ref{Union{Nothing,Int}}(nothing)
     mesh_cache = Dict{Int,Any}()
-    function delete_plot_obj!(obj)
-        obj === nothing && return nothing
-        if obj isa AbstractVector
-            for item in obj
-                delete!(ax, item)
-            end
-        else
-            delete!(ax, obj)
-        end
-        return nothing
-    end
-
-    function contour_plot_group!(data, group_levels)
-        objects = Any[]
-        for spec in contour_plot_specs(display_setup.contour_style, group_levels)
-            contour_kwargs = contour_plot_kwargs(spec.style, spec.levels)
-            push!(objects, GLMakie.contour!(
-                ax, x_physical, y_physical, z_physical, data; contour_kwargs...))
-        end
-        return objects
-    end
 
     if display_setup.render_kind == :contour
         dummy_data = zeros(Float64, NX, NY, NZ)
-        plot_obj[] = contour_plot_group!(dummy_data, [levels[1]])
+        plot_obj[] = contour_plot_group!(ax, dummy_data, [levels[1]],
+            display_setup.contour_style;
+            x_physical=x_physical, y_physical=y_physical, z_physical=z_physical)
     end
 
     function draw_slice!(slice4)
-        delete_plot_obj!(plot_obj[])
+        delete_plot_obj!(ax, plot_obj[])
 
         plaqs = @view plaqs_t[:, :, :, slice4]
         ax.title = movie_title
-
-        if display_setup.render_kind == :mesh
-            if cache_active
-                geometry = get!(mesh_cache, slice4) do
-                    mesh_geometry_for_slice(plaqs, display_setup;
-                        a=a, lattice_size=(NX, NY, NZ))
-                end
-                plot_obj[], _ = mesh_plot_geometry!(ax, geometry, display_setup)
-            else
-                geometry = mesh_geometry_for_slice(plaqs, display_setup;
-                    a=a, lattice_size=(NX, NY, NZ))
-                plot_obj[], _ = mesh_plot_geometry!(ax, geometry, display_setup)
-            end
-        else
-            plot_obj[] = contour_plot_group!(plaqs, levels)
-        end
+        plot_obj[] = plot_animation_slice!(ax, plaqs, display_setup, levels;
+            a=a,
+            lattice_size=(NX, NY, NZ),
+            x_physical=x_physical,
+            y_physical=y_physical,
+            z_physical=z_physical,
+            mesh_cache=cache_active ? mesh_cache : nothing,
+            slice4=slice4)
         limits!(ax, 0, a * NX, 0, a * NY, 0, a * NZ)
         current_slice4[] = slice4
         return nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,12 @@ using Wilsonloop
 const SAMPLE_BASENAME =
     "topological_density_noaxis_halfspeed"
 
+mutable struct DeleteRecorder
+    deleted::Vector{Any}
+end
+
+Base.delete!(recorder::DeleteRecorder, item) = (push!(recorder.deleted, item); recorder)
+
 function run_render_smoke_test()
     NX, NY, NZ, NT = VisualizingLQCD.CURRENT_TEST_LATTICE
     β = VisualizingLQCD.CURRENT_TEST_BETA
@@ -408,6 +414,26 @@ end
     @test_throws ArgumentError VisualizingLQCD.mesh_geometry_for_slice(
         fill(action_setup.body_level + 1, 2, 2, 2), unsupported_mesh_setup;
         a=1.0, lattice_size=(2, 2, 2))
+    render_cache = Dict{Int,Any}()
+    cached_action_geometry = VisualizingLQCD.mesh_geometry_for_render_slice(
+        fill(action_setup.body_level + 1, 2, 2, 2), action_setup;
+        a=1.0, lattice_size=(2, 2, 2), mesh_cache=render_cache, slice4=1)
+    cached_action_geometry_again = VisualizingLQCD.mesh_geometry_for_render_slice(
+        fill(0.0, 2, 2, 2), action_setup;
+        a=1.0, lattice_size=(2, 2, 2), mesh_cache=render_cache, slice4=1)
+    @test length(render_cache) == 1
+    @test cached_action_geometry_again.info.vertices ==
+          cached_action_geometry.info.vertices
+    @test_throws ArgumentError VisualizingLQCD.mesh_geometry_for_render_slice(
+        fill(action_setup.body_level + 1, 2, 2, 2), action_setup;
+        a=1.0, lattice_size=(2, 2, 2), mesh_cache=Dict{Int,Any}())
+    delete_recorder = DeleteRecorder(Any[])
+    @test VisualizingLQCD.delete_plot_obj!(delete_recorder, nothing) === nothing
+    @test isempty(delete_recorder.deleted)
+    @test VisualizingLQCD.delete_plot_obj!(delete_recorder, :single) === nothing
+    @test delete_recorder.deleted == Any[:single]
+    @test VisualizingLQCD.delete_plot_obj!(delete_recorder, [:a, :b]) === nothing
+    @test delete_recorder.deleted == Any[:single, :a, :b]
 
     topological_setup = VisualizingLQCD.topological_charge_display_level_setup(
         reshape([-4.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0], 2, 2, 2, 1);


### PR DESCRIPTION
## Summary
- Extract plot-object deletion, contour plot grouping, mesh-cache geometry lookup, and per-slice plot dispatch from `create_animation`.
- Keep gauge-field I/O, observable selection, metadata assembly, and actual GLMakie style behavior unchanged.
- Add unit coverage for mesh cache reuse and plot deletion behavior, plus update the refactor status memo.

## Validation
- `/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl` pass, 262 tests, render smoke skipped
- Direct `create_animation` smoke pass, wrote `/private/tmp/VisualizingLQCD-draw-helpers-smoke/smoke.mp4` and `/private/tmp/VisualizingLQCD-draw-helpers-smoke/smoke.metadata.json`
- Smoke metadata confirmed `frame_count=16` and `cached_slice_count=16`
- `git diff --check` pass

## Note
- I did not rerun `Pkg.test()` on this branch. PR #45 already recorded that it is blocked before tests by the existing `Qt6Base_jll 6.10.2+1` manifest vs registry mismatch. This PR does not modify `Project.toml` or `Manifest.toml`.