### PR TITLE
[codex] Extract display setup helper

### DIFF
--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,7 +4,66 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-11 after starting draw helper extraction.
+Last updated on 2026-05-11 after starting display setup extraction.
+
+## Active note: 2026-05-11 display setup extraction
+
+- Machine: `Akios-MacBook-Air.local`.
+- Workdir:
+
+```text
+/Users/akio/repository/VisualizingLQCD_v2/VisualizingLQCD.jl
+```
+
+- Branch: `codex/extract-display-setup`.
+- Starting point:
+  - PR #46 was still open and mergeable at the start of this work;
+  - PR #46 was merged while validation was running;
+  - after user confirmation, this branch was rebased onto the updated `main`.
+- Goal:
+  - continue reducing `create_animation` while preserving output behavior;
+  - move observable/display setup selection out of the main orchestration body;
+  - keep gauge-field loading, figure setup, drawing, metadata assembly, and file
+    output unchanged for this PR.
+- Scope:
+  - `animation_display_setup_for_gaugefield` takes an already-loaded gauge field
+    and returns `(display_setup, render_style)`;
+  - action-density, topological charge-density, legacy neglog plaquette, and raw
+    plaquette display paths keep the same validation and setup calls as before;
+  - `create_animation` now performs I/O first, then delegates observable/display
+    setup to that helper.
+- Current progress estimate:
+  - visualization refactor/user-facing pipeline: about `89%`;
+  - README/sample media path: about `90%`;
+  - physics-validation depth for topological charge density: about `70%`.
+- Main concerns:
+  - `create_animation` still owns gauge-field I/O, figure setup, metadata
+    assembly, and metadata writing;
+  - `Pkg.test()` remains blocked by the existing `Qt6Base_jll` manifest vs
+    registry mismatch until the package environment is deliberately refreshed.
+- Next likely PRs, in order:
+  1. Separate gauge-field loading into an I/O helper.
+  2. Separate metadata assembly from movie recording.
+  3. Clean up user-facing example command structure.
+  4. True instanton/SU(3)-embedded validation once Gaugefields.jl-side work is
+     ready.
+- Validation:
+
+```text
+/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
+result: pass, 273 tests, render smoke skipped
+
+direct create_animation smoke:
+result: pass, wrote:
+        /private/tmp/VisualizingLQCD-display-setup-smoke/smoke.mp4
+        /private/tmp/VisualizingLQCD-display-setup-smoke/smoke.metadata.json
+        metadata confirmed observable.kind=local_action_density,
+        render_style=action_density_blob, frame_count=16,
+        cached_slice_count=16
+
+git diff --check:
+result: pass
+```
 
 ## Active note: 2026-05-11 draw helper extraction
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -379,6 +379,58 @@ function record_animation_frames!(fig, ax, videoname, NT, camera, draw_slice!,
     return nothing
 end
 
+function animation_display_setup_for_gaugefield(U, NX, NY, NZ, NT, NC;
+    level_target=CURRENT_LEVEL_TARGET,
+    render_style=nothing,
+    raw_high_level_quantiles=nothing,
+    raw_high_color_quantiles=nothing,
+    topological_level_quantiles=nothing,
+    topological_color_quantile=nothing,
+    topological_style_preset=CURRENT_TOPOLOGICAL_CHARGE_STYLE_PRESET,
+    render_alpha=nothing,
+    render_transparency=nothing)
+
+    effective_render_style = something(render_style,
+        default_render_style_for_level_target(level_target))
+
+    if level_target == LEVEL_TARGET_ACTION_DENSITY_HIGH
+        effective_render_style == RENDER_STYLE_ACTION_DENSITY_BLOB ||
+            throw(ArgumentError("level_target=$level_target requires render_style=$RENDER_STYLE_ACTION_DENSITY_BLOB"))
+        action_density_t = local_action_density(U, NX, NY, NZ, NT, NC)
+        return (
+            display_setup=action_density_blob_display_setup(action_density_t),
+            render_style=effective_render_style,
+        )
+    elseif level_target == LEVEL_TARGET_TOPOLOGICAL_CHARGE_DENSITY
+        effective_render_style in (RENDER_STYLE_TOPOLOGICAL_CHARGE_SIGNED,
+            RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME) ||
+            throw(ArgumentError("level_target=$level_target requires render_style=$RENDER_STYLE_TOPOLOGICAL_CHARGE_SIGNED or $RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME"))
+        density_t = topological_charge_density(U, NX, NY, NZ, NT, NC)
+        return (
+            display_setup=topological_charge_display_level_setup(density_t;
+                style_preset=topological_style_preset,
+                level_quantiles=topological_level_quantiles,
+                color_quantile=topological_color_quantile,
+                render_style=effective_render_style,
+                render_alpha=render_alpha,
+                render_transparency=render_transparency),
+            render_style=effective_render_style,
+        )
+    end
+
+    raw_plaqs_t = plaquette_plane_deviation(U, NX, NY, NZ, NT, NC)
+    return (
+        display_setup=plaquette_display_level_setup(raw_plaqs_t;
+            level_target=level_target,
+            raw_high_level_quantiles=raw_high_level_quantiles,
+            raw_high_color_quantiles=raw_high_color_quantiles,
+            render_style=effective_render_style,
+            render_alpha=render_alpha,
+            render_transparency=render_transparency),
+        render_style=effective_render_style,
+    )
+end
+
 function create_animation(NX, NY, NZ, NT, NC, videoname;
     beta=CURRENT_BETA_ANIMATION_DEFAULT,
     flow_steps_in=CURRENT_FLOW_STEPS_ANIMATION_DEFAULT,
@@ -420,38 +472,18 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
         NC, Nwing, NX, NY, NZ, NT, condition=CURRENT_GENERATION_INITIAL_CONDITION)
     ildg = ILDG(filename)
     load_gaugefield!(U1, 1, ildg, [NX, NY, NZ, NT], NC)
-    effective_render_style = something(render_style,
-        default_render_style_for_level_target(level_target))
-
-    if level_target == LEVEL_TARGET_ACTION_DENSITY_HIGH
-        effective_render_style == RENDER_STYLE_ACTION_DENSITY_BLOB ||
-            throw(ArgumentError("level_target=$level_target requires render_style=$RENDER_STYLE_ACTION_DENSITY_BLOB"))
-        action_density_t = local_action_density(U1, NX, NY, NZ, NT, NC)
-        display_setup = action_density_blob_display_setup(action_density_t)
-    elseif level_target == LEVEL_TARGET_TOPOLOGICAL_CHARGE_DENSITY
-        effective_render_style in (RENDER_STYLE_TOPOLOGICAL_CHARGE_SIGNED,
-            RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME) ||
-            throw(ArgumentError("level_target=$level_target requires render_style=$RENDER_STYLE_TOPOLOGICAL_CHARGE_SIGNED or $RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME"))
-        density_t = topological_charge_density(U1, NX, NY, NZ, NT, NC)
-        display_setup = topological_charge_display_level_setup(density_t;
-            style_preset=topological_style_preset,
-            level_quantiles=topological_level_quantiles,
-            color_quantile=topological_color_quantile,
-            render_style=effective_render_style,
-            render_alpha=render_alpha,
-            render_transparency=render_transparency)
-    else
-        # Calculating field strength using plaquette.
-        # In precise, we need 1/β.
-        raw_plaqs_t = plaquette_plane_deviation(U1, NX, NY, NZ, NT, NC)
-        display_setup = plaquette_display_level_setup(raw_plaqs_t;
-            level_target=level_target,
-            raw_high_level_quantiles=raw_high_level_quantiles,
-            raw_high_color_quantiles=raw_high_color_quantiles,
-            render_style=effective_render_style,
-            render_alpha=render_alpha,
-            render_transparency=render_transparency)
-    end
+    display_result = animation_display_setup_for_gaugefield(U1, NX, NY, NZ, NT, NC;
+        level_target=level_target,
+        render_style=render_style,
+        raw_high_level_quantiles=raw_high_level_quantiles,
+        raw_high_color_quantiles=raw_high_color_quantiles,
+        topological_level_quantiles=topological_level_quantiles,
+        topological_color_quantile=topological_color_quantile,
+        topological_style_preset=topological_style_preset,
+        render_alpha=render_alpha,
+        render_transparency=render_transparency)
+    display_setup = display_result.display_setup
+    effective_render_style = display_result.render_style
     plaqs_t = display_setup.display_field
     effective_theme = effective_render_theme(effective_render_style, render_theme)
     theme_settings = render_theme_settings(effective_theme)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -264,6 +264,25 @@ end
     @test VisualizingLQCD.default_render_style_for_level_target(
         VisualizingLQCD.LEVEL_TARGET_LEGACY_NEGLOG_HIGH) ==
           VisualizingLQCD.RENDER_STYLE_CURRENT
+    setup_u = VisualizingLQCD.Initialize_Gaugefields(
+        3, 0, 2, 2, 2, 2; condition=VisualizingLQCD.CURRENT_GENERATION_INITIAL_CONDITION)
+    action_display_result = VisualizingLQCD.animation_display_setup_for_gaugefield(
+        setup_u, 2, 2, 2, 2, 3;
+        level_target=VisualizingLQCD.LEVEL_TARGET_ACTION_DENSITY_HIGH)
+    @test action_display_result.render_style == VisualizingLQCD.RENDER_STYLE_ACTION_DENSITY_BLOB
+    @test action_display_result.display_setup.render_kind == :mesh
+    @test action_display_result.display_setup.observable_info["kind"] == "local_action_density"
+    legacy_display_result = VisualizingLQCD.animation_display_setup_for_gaugefield(
+        setup_u, 2, 2, 2, 2, 3;
+        level_target=VisualizingLQCD.LEVEL_TARGET_LEGACY_NEGLOG_HIGH,
+        render_style=VisualizingLQCD.RENDER_STYLE_CURRENT)
+    @test legacy_display_result.render_style == VisualizingLQCD.RENDER_STYLE_CURRENT
+    @test legacy_display_result.display_setup.render_kind == :contour
+    @test legacy_display_result.display_setup.display_transform_info["kind"] == "neglog"
+    @test_throws ArgumentError VisualizingLQCD.animation_display_setup_for_gaugefield(
+        setup_u, 2, 2, 2, 2, 3;
+        level_target=VisualizingLQCD.LEVEL_TARGET_ACTION_DENSITY_HIGH,
+        render_style=VisualizingLQCD.RENDER_STYLE_CURRENT)
 
     @test VisualizingLQCD.plaquette_loop(1, 3) == [(1, 1), (3, 1), (1, -1), (3, -1)]
     @test VisualizingLQCD.legacy_mean_std_levels(
@@ -611,6 +630,22 @@ end
     reference_charge = reference_clover_topological_charge(instanton_u)
     @test density_charge ≈ reference_charge atol = 1e-10
     @test abs(density_charge) > 0.5
+    topological_display_result = VisualizingLQCD.animation_display_setup_for_gaugefield(
+        instanton_u,
+        instanton_lattice,
+        instanton_lattice,
+        instanton_lattice,
+        instanton_lattice,
+        instanton_nc;
+        level_target=VisualizingLQCD.LEVEL_TARGET_TOPOLOGICAL_CHARGE_DENSITY,
+        render_style=VisualizingLQCD.RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME)
+    @test topological_display_result.render_style ==
+          VisualizingLQCD.RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME
+    @test topological_display_result.display_setup.render_kind == :mesh
+    @test topological_display_result.display_setup.mesh_renderer ==
+          :topological_charge_volume
+    @test size(topological_display_result.display_setup.display_field) ==
+          size(instanton_density)
 end
 
 @testset "SU(2) instanton density fixture contracts" begin


### PR DESCRIPTION
## Summary
- Extract observable/display setup selection from `create_animation` into `animation_display_setup_for_gaugefield`.
- Keep gauge-field loading, figure setup, drawing, metadata assembly, and file output unchanged.
- Add contract coverage for action-density, legacy plaquette, and topological charge-density display setup paths.

## Validation
- `/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl` pass, 273 tests, render smoke skipped
- Direct `create_animation` smoke pass, wrote `/private/tmp/VisualizingLQCD-display-setup-smoke/smoke.mp4` and `/private/tmp/VisualizingLQCD-display-setup-smoke/smoke.metadata.json`
- Smoke metadata confirmed `observable.kind=local_action_density`, `render_style=action_density_blob`, `frame_count=16`, `cached_slice_count=16`
- `git diff --check` pass

## Note
- This branch was rebased onto `main` after PR #46 merged.
- `Pkg.test()` remains blocked by the existing `Qt6Base_jll 6.10.2+1` manifest vs registry mismatch recorded in PR #45; this PR does not modify `Project.toml` or `Manifest.toml`.