### PR TITLE
[codex] Extract gauge field loading helper

### DIFF
--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,7 +4,63 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-11 after starting display setup extraction.
+Last updated on 2026-05-11 after starting gauge-field I/O extraction.
+
+## Active note: 2026-05-11 gauge-field I/O extraction
+
+- Machine: `Akios-MacBook-Air.local`.
+- Workdir:
+
+```text
+/Users/akio/repository/VisualizingLQCD_v2/VisualizingLQCD.jl
+```
+
+- Branch: `codex/extract-gaugefield-io`.
+- Starting point: PR #47 was merged into `main`.
+- Goal:
+  - continue reducing `create_animation` while preserving output behavior;
+  - move gauge-field initialization and ILDG loading into I/O helpers;
+  - keep display setup, figure setup, drawing, metadata assembly, and file output
+    unchanged for this PR.
+- Scope:
+  - `initialize_animation_gaugefield` owns `Initialize_Gaugefields` defaults for
+    animation loading;
+  - `load_animation_gaugefield` owns `ILDG(filename)` and `load_gaugefield!`;
+  - `create_animation` now delegates the gauge-field loading step before calling
+    `animation_display_setup_for_gaugefield`.
+- Current progress estimate:
+  - visualization refactor/user-facing pipeline: about `90%`;
+  - README/sample media path: about `90%`;
+  - physics-validation depth for topological charge density: about `70%`.
+- Main concerns:
+  - `create_animation` still owns figure setup, metadata assembly, and metadata
+    writing;
+  - `Pkg.test()` remains blocked by the existing `Qt6Base_jll` manifest vs
+    registry mismatch until the package environment is deliberately refreshed;
+  - GLMakie/direct smoke remains the practical guard for render-path movement.
+- Next likely PRs, in order:
+  1. Separate metadata assembly from movie recording.
+  2. Clean up user-facing example command structure.
+  3. Consider a deliberate package-environment refresh for `Pkg.test`.
+  4. True instanton/SU(3)-embedded validation once Gaugefields.jl-side work is
+     ready.
+- Validation:
+
+```text
+/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
+result: pass, 276 tests, render smoke skipped
+
+/Users/akio/.juliaup/bin/julia --project=. -e 'using VisualizingLQCD; ...'
+result: pass, direct create_animation smoke wrote:
+        /private/tmp/VisualizingLQCD-gaugefield-io-smoke/smoke.mp4
+        /private/tmp/VisualizingLQCD-gaugefield-io-smoke/smoke.metadata.json
+        metadata confirmed filename=/private/tmp/VisualizingLQCD-gaugefield-io-smoke/smoke.ildg,
+        observable.kind=local_action_density, render_style=action_density_blob,
+        frame_count=16, cached_slice_count=16
+
+git diff --check
+result: pass
+```
 
 ## Active note: 2026-05-11 display setup extraction
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -431,6 +431,24 @@ function animation_display_setup_for_gaugefield(U, NX, NY, NZ, NT, NC;
     )
 end
 
+function initialize_animation_gaugefield(NX, NY, NZ, NT, NC;
+    nwing=CURRENT_NWING,
+    condition=CURRENT_GENERATION_INITIAL_CONDITION)
+
+    return Initialize_Gaugefields(NC, nwing, NX, NY, NZ, NT; condition=condition)
+end
+
+function load_animation_gaugefield(filename, NX, NY, NZ, NT, NC;
+    nwing=CURRENT_NWING,
+    condition=CURRENT_GENERATION_INITIAL_CONDITION)
+
+    U = initialize_animation_gaugefield(NX, NY, NZ, NT, NC;
+        nwing=nwing, condition=condition)
+    ildg = ILDG(filename)
+    load_gaugefield!(U, 1, ildg, [NX, NY, NZ, NT], NC)
+    return U
+end
+
 function create_animation(NX, NY, NZ, NT, NC, videoname;
     beta=CURRENT_BETA_ANIMATION_DEFAULT,
     flow_steps_in=CURRENT_FLOW_STEPS_ANIMATION_DEFAULT,
@@ -464,14 +482,10 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
     show_axis_labels=CURRENT_SHOW_AXIS_LABELS)
 
     #function create_animation(NX, NY, NZ, NT, NC; beta=6.1, filename="conf_00000100.ildg")
-    Nwing = CURRENT_NWING
     a = calculate_a(beta)
     scale_factor = a
 
-    U1 = Initialize_Gaugefields(
-        NC, Nwing, NX, NY, NZ, NT, condition=CURRENT_GENERATION_INITIAL_CONDITION)
-    ildg = ILDG(filename)
-    load_gaugefield!(U1, 1, ildg, [NX, NY, NZ, NT], NC)
+    U1 = load_animation_gaugefield(filename, NX, NY, NZ, NT, NC)
     display_result = animation_display_setup_for_gaugefield(U1, NX, NY, NZ, NT, NC;
         level_target=level_target,
         render_style=render_style,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -264,6 +264,10 @@ end
     @test VisualizingLQCD.default_render_style_for_level_target(
         VisualizingLQCD.LEVEL_TARGET_LEGACY_NEGLOG_HIGH) ==
           VisualizingLQCD.RENDER_STYLE_CURRENT
+    initialized_u = VisualizingLQCD.initialize_animation_gaugefield(2, 2, 2, 2, 3)
+    @test length(initialized_u) == 4
+    @test initialized_u[1].NC == 3
+    @test initialized_u[1].NV == 16
     setup_u = VisualizingLQCD.Initialize_Gaugefields(
         3, 0, 2, 2, 2, 2; condition=VisualizingLQCD.CURRENT_GENERATION_INITIAL_CONDITION)
     action_display_result = VisualizingLQCD.animation_display_setup_for_gaugefield(


### PR DESCRIPTION
## Summary
- Extract animation gauge-field initialization and ILDG loading into `initialize_animation_gaugefield` and `load_animation_gaugefield`.
- Keep display setup, figure setup, drawing, metadata assembly, and file output unchanged.
- Add a small contract check for the initialized animation gauge-field shape.

## Validation
- `/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl` pass, 276 tests, render smoke skipped
- Direct `create_animation` smoke pass, wrote `/private/tmp/VisualizingLQCD-gaugefield-io-smoke/smoke.mp4` and `/private/tmp/VisualizingLQCD-gaugefield-io-smoke/smoke.metadata.json`
- Smoke metadata confirmed the input filename, `observable.kind=local_action_density`, `render_style=action_density_blob`, `frame_count=16`, and `cached_slice_count=16`
- `git diff --check` pass

## Note
- `Pkg.test()` remains blocked by the existing `Qt6Base_jll 6.10.2+1` manifest vs registry mismatch recorded earlier; this PR does not modify `Project.toml` or `Manifest.toml`.