### PR TITLE
[codex] Extract metadata assembly helper

### DIFF
--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,7 +4,62 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-11 after starting gauge-field I/O extraction.
+Last updated on 2026-05-11 after validating metadata assembly extraction.
+
+## Active note: 2026-05-11 metadata assembly extraction
+
+- Machine: `Akios-MacBook-Air.local`.
+- Workdir:
+
+```text
+/Users/akio/repository/VisualizingLQCD_v2/VisualizingLQCD.jl
+```
+
+- Branch: `codex/extract-metadata-assembly`.
+- Starting point: PR #48 was merged into `main`.
+- Goal:
+  - continue reducing `create_animation` while preserving output behavior;
+  - move the metadata dict construction into a helper;
+  - keep gauge-field loading, display setup, figure setup, drawing, movie
+    recording, metadata writing, and file output unchanged for this PR.
+- Scope:
+  - `animation_metadata_for_render` collects metadata from `display_setup`,
+    `render_plan`, `camera`, `render_theme`, and `mesh_cache`;
+  - `create_animation` now records the movie, asks the helper for metadata, writes
+    the sidecar, and returns the same `(video, metadata)` contract;
+  - metadata schema and field values are intended to remain identical.
+- Current progress estimate:
+  - visualization refactor/user-facing pipeline: about `91%`;
+  - README/sample media path: about `90%`;
+  - physics-validation depth for topological charge density: about `70%`.
+- Main concerns:
+  - `create_animation` still owns figure setup and metadata writing;
+  - `Pkg.test()` remains blocked by the existing `Qt6Base_jll` manifest vs
+    registry mismatch until the package environment is deliberately refreshed;
+  - GLMakie/direct smoke remains the practical guard for render-path movement.
+- Next likely PRs, in order:
+  1. Move metadata writing/return-value finalization into a tiny output helper.
+  2. Clean up user-facing example command structure.
+  3. Consider a deliberate package-environment refresh for `Pkg.test`.
+  4. True instanton/SU(3)-embedded validation once Gaugefields.jl-side work is
+     ready.
+- Validation:
+
+```text
+/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
+result: pass, 283 tests, render smoke skipped
+
+/Users/akio/.juliaup/bin/julia --project=. -e 'using VisualizingLQCD; ...'
+result: pass, direct create_animation smoke wrote:
+        /private/tmp/VisualizingLQCD-metadata-assembly-smoke/smoke.mp4
+        /private/tmp/VisualizingLQCD-metadata-assembly-smoke/smoke.metadata.json
+        metadata confirmed filename=/private/tmp/VisualizingLQCD-metadata-assembly-smoke/smoke.ildg,
+        observable.kind=local_action_density, render_style=action_density_blob,
+        frame_count=16, cached_slice_count=16
+
+git diff --check
+result: pass
+```
 
 ## Active note: 2026-05-11 gauge-field I/O extraction
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -449,6 +449,43 @@ function load_animation_gaugefield(filename, NX, NY, NZ, NT, NC;
     return U
 end
 
+function animation_metadata_for_render(; videoname, metadata_filename, filename,
+    lattice_size, nc, beta, flow_steps, display_setup, render_theme, render_plan,
+    camera, mesh_cache)
+
+    return animation_metadata(
+        videoname=videoname,
+        metadata_filename=metadata_filename,
+        filename=filename,
+        lattice_size=lattice_size,
+        nc=nc,
+        beta=beta,
+        flow_steps=flow_steps,
+        levels=display_setup.levels,
+        level_summary=display_setup.level_summary,
+        framerate=render_plan.framerate,
+        nloops=render_plan.nloops,
+        title=display_setup.title,
+        figure_size=render_plan.figure_size,
+        frame_mode=render_plan.frame_mode,
+        fixed_slice4=render_plan.fixed_slice4,
+        slice_hold_frames=render_plan.slice_hold_frames,
+        display_transform_info=display_setup.display_transform_info,
+        level_selection_info=display_setup.level_selection_info,
+        render_style_info=display_setup.render_style_info,
+        render_theme_info=render_theme_metadata(render_theme),
+        render_progress_info=render_progress_metadata(render_plan.show_render_progress),
+        render_axis_info=render_axis_metadata(render_plan.show_axis_labels),
+        camera_info=camera_motion_metadata(camera),
+        render_cache_info=Dict(
+            "cache_render_slices" => render_plan.cache_active,
+            "cached_slice_count" => length(mesh_cache),
+            "cache_key" => "slice4",
+        ),
+        observable_info=display_setup.observable_info,
+    )
+end
+
 function create_animation(NX, NY, NZ, NT, NC, videoname;
     beta=CURRENT_BETA_ANIMATION_DEFAULT,
     flow_steps_in=CURRENT_FLOW_STEPS_ANIMATION_DEFAULT,
@@ -525,12 +562,7 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
         figure_size=figure_size,
         show_render_progress=show_render_progress,
         show_axis_labels=show_axis_labels)
-    effective_framerate = render_plan.framerate
-    effective_frame_mode = render_plan.frame_mode
-    effective_slice_hold_frames = render_plan.slice_hold_frames
-    effective_nloops = render_plan.nloops
     effective_figure_size = render_plan.figure_size
-    effective_show_render_progress = render_plan.show_render_progress
     effective_show_axis_labels = render_plan.show_axis_labels
     cache_active = render_plan.cache_active
 
@@ -590,7 +622,7 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
     record_animation_frames!(fig, ax, videoname, NT, camera, draw_slice!, current_slice4,
         render_plan)
 
-    metadata = animation_metadata(
+    metadata = animation_metadata_for_render(
         videoname=videoname,
         metadata_filename=metadata_filename,
         filename=filename,
@@ -598,29 +630,11 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
         nc=NC,
         beta=beta,
         flow_steps=flow_steps_in,
-        levels=levels,
-        level_summary=level_summary,
-        framerate=effective_framerate,
-        nloops=effective_nloops,
-        title=movie_title,
-        figure_size=effective_figure_size,
-        frame_mode=effective_frame_mode,
-        fixed_slice4=fixed_slice4,
-        slice_hold_frames=effective_slice_hold_frames,
-        display_transform_info=display_setup.display_transform_info,
-        level_selection_info=display_setup.level_selection_info,
-        render_style_info=display_setup.render_style_info,
-        render_theme_info=render_theme_metadata(effective_theme),
-        render_progress_info=render_progress_metadata(effective_show_render_progress),
-        render_axis_info=render_axis_metadata(effective_show_axis_labels),
-        camera_info=camera_motion_metadata(camera),
-        render_cache_info=Dict(
-            "cache_render_slices" => cache_active,
-            "cached_slice_count" => length(mesh_cache),
-            "cache_key" => "slice4",
-        ),
-        observable_info=display_setup.observable_info,
-    )
+        display_setup=display_setup,
+        render_theme=effective_theme,
+        render_plan=render_plan,
+        camera=camera,
+        mesh_cache=mesh_cache)
     write_animation_metadata(metadata_filename, metadata)
     return (video=videoname, metadata=metadata_filename)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,6 +234,51 @@ end
     @test length(metadata["frame_map"]) == metadata["render"]["frame_count"]
     @test metadata["frame_map"][1] == Dict("frame" => 1, "slice4" => 1)
     @test metadata["frame_map"][end] == Dict("frame" => 128, "slice4" => 32)
+    sample_display_setup = (
+        levels=[
+            -0.0006161936800660506,
+            -0.00020275648206484858,
+            0.00020275648206484858,
+            0.0006161936800660506,
+        ],
+        level_summary=sample_summary,
+        title="Topological charge density",
+        display_transform_info=VisualizingLQCD.topological_charge_display_transform_metadata(),
+        level_selection_info=Dict("level_target" => "topological_charge_density"),
+        render_style_info=Dict("render_style" => "topological_charge_volume"),
+        observable_info=VisualizingLQCD.topological_charge_density_observable_metadata(),
+    )
+    sample_render_plan = (
+        framerate=8,
+        nloops=4,
+        figure_size=(480, 480),
+        frame_mode=VisualizingLQCD.FRAME_MODE_SEQUENCE,
+        fixed_slice4=nothing,
+        slice_hold_frames=1,
+        show_render_progress=false,
+        show_axis_labels=false,
+        cache_active=true,
+    )
+    assembled_metadata = VisualizingLQCD.animation_metadata_for_render(
+        videoname="$(SAMPLE_BASENAME).mp4",
+        metadata_filename="$(SAMPLE_BASENAME).mp4.metadata.json",
+        filename="Conf24242432beta6.0.ildg",
+        lattice_size=sample_lattice,
+        nc=3,
+        beta=6.0,
+        flow_steps=200,
+        display_setup=sample_display_setup,
+        render_theme=VisualizingLQCD.RENDER_THEME_DARK,
+        render_plan=sample_render_plan,
+        camera=sample_camera,
+        mesh_cache=Dict(1 => :slice1, 2 => :slice2))
+    @test assembled_metadata["render"]["frame_count"] == 128
+    @test assembled_metadata["render"]["cached_slice_count"] == 2
+    @test assembled_metadata["render"]["cache_render_slices"] == true
+    @test assembled_metadata["render"]["render_theme"] == "dark"
+    @test assembled_metadata["render"]["show_render_progress"] == false
+    @test assembled_metadata["render"]["show_axis_labels"] == false
+    @test assembled_metadata["observable"]["kind"] == "topological_charge_density"
 end
 
 @testset "Display and render setup contracts" begin


### PR DESCRIPTION
## Summary
- Extract metadata dict construction from create_animation into animation_metadata_for_render.
- Keep gauge-field loading, display setup, figure setup, drawing, movie recording, metadata writing, and file output unchanged.
- Add contract coverage for render metadata assembly using display_setup/render_plan/camera/cache inputs.

## Validation
- /Users/akio/.juliaup/bin/julia --project=. test/runtests.jl pass, 283 tests, render smoke skipped
- Direct create_animation smoke pass, wrote /private/tmp/VisualizingLQCD-metadata-assembly-smoke/smoke.mp4 and /private/tmp/VisualizingLQCD-metadata-assembly-smoke/smoke.metadata.json
- Smoke metadata confirmed filename, observable.kind=local_action_density, render_style=action_density_blob, frame_count=16, cached_slice_count=16
- git diff --check pass

## Note
- Pkg.test remains blocked by the existing Qt6Base_jll 6.10.2+1 manifest vs registry mismatch; this PR does not modify Project.toml or Manifest.toml.