### PR TITLE
[codex] Extract animation scene setup

### DIFF
--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,7 +4,66 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-11 after validating animation output finalization.
+Last updated on 2026-05-11 after validating animation scene setup extraction.
+
+## Active note: 2026-05-11 animation scene setup extraction
+
+- Machine: `Akios-MacBook-Air.local`.
+- Workdir:
+
+```text
+/Users/akio/repository/VisualizingLQCD_v2/VisualizingLQCD.jl
+```
+
+- Branch: `codex/extract-animation-scene-setup`.
+- Starting point: PR #50 was merged into `main`.
+- Goal:
+  - continue reducing `create_animation` while preserving output behavior;
+  - move spatial coordinate calculation and Figure/Axis3 initialization into
+    helpers;
+  - keep rendering, metadata contents, and output paths unchanged.
+- Scope:
+  - `animation_spatial_coordinates` owns the physical coordinate ranges and axis
+    limits derived from lattice spacing and spatial lattice size;
+  - `initialize_animation_scene` owns Figure creation, axis keyword assembly,
+    Axis3 construction, and initial axis limits;
+  - `create_animation` still owns the local `draw_slice!` closure and render
+    orchestration.
+- Current progress estimate:
+  - visualization refactor/user-facing pipeline: about `93%`;
+  - README/sample media path: about `90%`;
+  - physics-validation depth for topological charge density: about `70%`.
+- Main concerns:
+  - `create_animation` still owns `draw_slice!`, cache lifetime, and the final
+    render orchestration;
+  - extracting `draw_slice!` will touch the hottest visual path, so it should be
+    a cautious PR with direct smoke before and after;
+  - `Pkg.test()` remains blocked by the existing `Qt6Base_jll` manifest vs
+    registry mismatch until the package environment is deliberately refreshed.
+- Next likely PRs, in order:
+  1. Either extract a tiny draw-context helper, or stop the refactor here and
+     clean up user-facing example command structure.
+  2. Consider a deliberate package-environment refresh for `Pkg.test`.
+  3. True instanton/SU(3)-embedded validation once Gaugefields.jl-side work is
+     ready.
+- Validation:
+
+```text
+/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
+result: pass, 292 tests, render smoke skipped
+
+/Users/akio/.juliaup/bin/julia --project=. -e 'using VisualizingLQCD; ...'
+result: pass, direct create_animation smoke wrote:
+        /private/tmp/VisualizingLQCD-scene-setup-smoke/smoke.mp4
+        /private/tmp/VisualizingLQCD-scene-setup-smoke/smoke.metadata.json
+        metadata confirmed filename=/private/tmp/VisualizingLQCD-scene-setup-smoke/smoke.ildg,
+        frame_mode=fixed_slice4, fixed_slice4=1,
+        observable.kind=local_action_density, render_style=action_density_blob,
+        frame_count=16, cached_slice_count=1, figure_size=[800, 800]
+
+git diff --check
+result: pass
+```
 
 ## Active note: 2026-05-11 animation output finalization
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -355,6 +355,38 @@ function animation_axis_kwargs(display_setup, theme_settings, camera;
     return axis_kwargs
 end
 
+function animation_spatial_coordinates(a::Real, lattice_size)
+    NX, NY, NZ = lattice_size
+    return (
+        x_physical=(a, a * NX),
+        y_physical=(a, a * NY),
+        z_physical=(a, a * NZ),
+        axis_limits=(0, a * NX, 0, a * NY, 0, a * NZ),
+    )
+end
+
+function initialize_animation_scene(display_setup, theme_settings, camera;
+    a, lattice_size, movie_title, figure_size, show_axis_labels::Bool)
+
+    coordinates = animation_spatial_coordinates(a, lattice_size)
+    fig = Figure(size=figure_size, backgroundcolor=theme_settings.figure_background)
+    axis_kwargs = animation_axis_kwargs(display_setup, theme_settings, camera;
+        a=a,
+        lattice_size=lattice_size,
+        movie_title=movie_title,
+        show_axis_labels=show_axis_labels)
+    ax = Axis3(fig[1, 1]; axis_kwargs...)
+    limits!(ax, coordinates.axis_limits...)
+    return (
+        fig=fig,
+        ax=ax,
+        x_physical=coordinates.x_physical,
+        y_physical=coordinates.y_physical,
+        z_physical=coordinates.z_physical,
+        axis_limits=coordinates.axis_limits,
+    )
+end
+
 function record_animation_frames!(fig, ax, videoname, NT, camera, draw_slice!,
     current_slice4, render_plan)
 
@@ -577,23 +609,14 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
     display(hist_p)
     =#
 
-    # Set coordinate
-    x_physical = (a, a * NX)
-    y_physical = (a, a * NY)
-    z_physical = (a, a * NZ)
-
-    fig = Figure(
-        size=effective_figure_size,
-        backgroundcolor=theme_settings.figure_background)
-    axis_kwargs = animation_axis_kwargs(display_setup, theme_settings, camera;
+    scene = initialize_animation_scene(display_setup, theme_settings, camera;
         a=a,
         lattice_size=(NX, NY, NZ),
         movie_title=movie_title,
+        figure_size=effective_figure_size,
         show_axis_labels=effective_show_axis_labels)
-
-    # Make Axis3
-    ax = Axis3(fig[1, 1]; axis_kwargs...)
-    limits!(ax, 0, a * NX, 0, a * NY, 0, a * NZ)
+    fig = scene.fig
+    ax = scene.ax
 
     plot_obj = Ref{Any}(nothing)
     current_slice4 = Ref{Union{Nothing,Int}}(nothing)
@@ -603,7 +626,9 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
         dummy_data = zeros(Float64, NX, NY, NZ)
         plot_obj[] = contour_plot_group!(ax, dummy_data, [levels[1]],
             display_setup.contour_style;
-            x_physical=x_physical, y_physical=y_physical, z_physical=z_physical)
+            x_physical=scene.x_physical,
+            y_physical=scene.y_physical,
+            z_physical=scene.z_physical)
     end
 
     function draw_slice!(slice4)
@@ -614,12 +639,12 @@ function create_animation(NX, NY, NZ, NT, NC, videoname;
         plot_obj[] = plot_animation_slice!(ax, plaqs, display_setup, levels;
             a=a,
             lattice_size=(NX, NY, NZ),
-            x_physical=x_physical,
-            y_physical=y_physical,
-            z_physical=z_physical,
+            x_physical=scene.x_physical,
+            y_physical=scene.y_physical,
+            z_physical=scene.z_physical,
             mesh_cache=cache_active ? mesh_cache : nothing,
             slice4=slice4)
-        limits!(ax, 0, a * NX, 0, a * NY, 0, a * NZ)
+        limits!(ax, scene.axis_limits...)
         current_slice4[] = slice4
         return nothing
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -460,6 +460,11 @@ end
     @test all(==(""), axis_kwargs[:xticks][2])
     @test axis_kwargs[:azimuth] == 0.0
     @test axis_kwargs[:elevation] == 0.5
+    coordinates = VisualizingLQCD.animation_spatial_coordinates(0.1, (4, 5, 6))
+    @test coordinates.x_physical == (0.1, 0.4)
+    @test coordinates.y_physical == (0.1, 0.5)
+    @test all(isapprox.(coordinates.z_physical, (0.1, 0.6)))
+    @test all(isapprox.(coordinates.axis_limits, (0, 0.4, 0, 0.5, 0, 0.6)))
     @test VisualizingLQCD.action_density_blob_color(0.5; qmin=0.0, qmax=1.0) isa
           VisualizingLQCD.Vec3f
     positive_low_color = VisualizingLQCD.topological_charge_volume_magnitude_color(


### PR DESCRIPTION
## Summary
- Add `animation_spatial_coordinates` for physical coordinate ranges and axis limits.
- Add `initialize_animation_scene` for Figure/Axis3 setup and initial axis limits.
- Keep rendering, metadata contents, output paths, and `create_animation` behavior unchanged.

## Validation
- `/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl` pass, 292 tests, render smoke skipped
- Direct `create_animation` smoke pass, wrote `/private/tmp/VisualizingLQCD-scene-setup-smoke/smoke.mp4` and `/private/tmp/VisualizingLQCD-scene-setup-smoke/smoke.metadata.json`
- Smoke metadata confirmed `filename`, `frame_mode=fixed_slice4`, `fixed_slice4=1`, `observable.kind=local_action_density`, `render_style=action_density_blob`, `frame_count=16`, `cached_slice_count=1`, `figure_size=[800, 800]`
- `git diff --check` pass

## Note
- `Pkg.test` remains blocked by the existing `Qt6Base_jll 6.10.2+1` manifest vs registry mismatch; this PR does not modify `Project.toml` or `Manifest.toml`.