### PR TITLE
[codex] Refresh README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,20 @@ The fourth lattice direction is shown as a sequence of Euclidean slices; it is n
 # How to use
 
 This uses [Julia](https://julialang.org/).
-Please down load it from [here](https://julialang.org/downloads/).
+Please download it from [here](https://julialang.org/downloads/).
 
 ## Install
-In REPL, press ] key. 
+In the Julia REPL, press `]` to enter package mode:
+
 ```
 add VisualizingLQCD.jl
 ```
-If there are some problems, it might be better to use 
+
+For local development from a checkout, activate the repository environment:
+
 ```
 activate .
 ```
-This means you can use clean environment. 
 
 ## Visualization from an existing configuration
 
@@ -42,7 +44,7 @@ function main()
     NC = 3
 
     confname = "Conf$(NX)$(NY)$(NZ)$(NT)beta$(β).ildg"
-    videoname = "plaquette_3D_contour_animation$(NX)$(NY)$(NZ)$(NT)beta$(β).mp4"
+    videoname = "action_density_blob$(NX)$(NY)$(NZ)$(NT)beta$(β).mp4"
 
     # Default: local action-density blob visualization
     create_animation(NX, NY, NZ, NT, NC, videoname; beta=β, filename=confname)
@@ -73,6 +75,8 @@ upper-tail `|q|` quantiles `(0.94, 0.999)`, and the mesh color encodes local
 `abs(q)`: positive charge progresses from yellow/orange to red, while negative
 charge progresses from cyan to blue.
 
+For a direct Julia API call:
+
 ```julia
 topological_videoname = "topological_density_noaxis_halfspeed.mp4"
 
@@ -99,6 +103,32 @@ threshold quantiles, color method, and observable definition. For a contour
 version instead of filled volume meshes, use
 `render_style=VisualizingLQCD.RENDER_STYLE_TOPOLOGICAL_CHARGE_SIGNED`.
 
+## Reproducing the bundled README sample
+
+The bundled README sample uses the topological charge-density volume renderer,
+the periodic fourth-direction sequence, and one camera turn. The reviewed input
+configuration is:
+
+```text
+/Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg
+```
+
+The same sample can be regenerated with the repository helper script:
+
+```sh
+/Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_topological_density_config_movie.jl --nx 24 --ny 24 --nz 24 --nt 32 --nc 3 --beta 6.0 --input /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg --output-name topological_density_noaxis_halfspeed.mp4 --render-mode volume --camera-motion orbit --frame-mode sequence --camera-orbit-turns 1 --nloops 4 --framerate 8 --figure-size 480 --show-axis-labels false --show-render-progress true --output-dir /private/tmp/VisualizingLQCD-topological-readme-sample
+```
+
+This command uses the direct API settings shown in the topological charge
+density example above.
+
+For the bundled `24^3 x 32` sample this gives `128` frames: all `32` Euclidean
+fourth-direction slices are shown four times while the camera completes one
+full turn. The source movie is rendered at `480 x 480`; the bundled README GIF
+is downsampled to `300` px to keep the repository size manageable. Axis labels
+are hidden in the bundled README movie to avoid label shimmer during the camera
+orbit; the 3D box and grid remain visible.
+
 To rotate the camera during the movie, use `camera_motion=:orbit`. Orbit movies
 keep one fourth-direction slice fixed by default, so the shape is not changed by
 the slice sequence while the camera rotates. It also uses `viewmode=:fit` and
@@ -121,34 +151,6 @@ To rotate while stepping through fourth-direction slices, pass
 `frame_mode=VisualizingLQCD.FRAME_MODE_SEQUENCE`.
 Repeated action-density meshes are cached by slice by default; pass
 `cache_render_slices=false` to disable this.
-
-The bundled README sample uses the topological charge-density volume renderer,
-the periodic fourth-direction sequence, and one camera turn:
-
-```julia
-create_animation(
-    NX, NY, NZ, NT, NC, topological_videoname;
-    beta=β,
-    filename=confname,
-    level_target=VisualizingLQCD.LEVEL_TARGET_TOPOLOGICAL_CHARGE_DENSITY,
-    render_style=VisualizingLQCD.RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME,
-    camera_motion=VisualizingLQCD.CAMERA_MOTION_ORBIT,
-    frame_mode=VisualizingLQCD.FRAME_MODE_SEQUENCE,
-    camera_orbit_turns=1,
-    nloops=4,
-    framerate=8,
-    figure_size=(480, 480),
-    show_axis_labels=false,
-    show_render_progress=true,
-)
-```
-
-For the bundled `24^3 x 32` sample this gives `128` frames: all `32` Euclidean
-fourth-direction slices are shown four times while the camera completes one
-full turn. The source movie is rendered at `480 x 480`; the bundled README GIF
-is downsampled to `300` px to keep the repository size manageable. Axis labels
-are hidden in the bundled README movie to avoid label shimmer during the camera
-orbit; the 3D box and grid remain visible.
 
 ## Visualization from scratch
 

--- a/docs/codex/topological_density_sample_commands.md
+++ b/docs/codex/topological_density_sample_commands.md
@@ -1,6 +1,6 @@
 # Topological Density Sample Commands
 
-Last updated: 2026-05-11
+Last updated: 2026-05-12
 
 This memo records the reproducible command path for the reviewed
 topological-charge-density README sample. It is intentionally separate from
@@ -9,8 +9,8 @@ main status memo.
 
 ## Current Progress
 
-- User-facing visualization pipeline: about `85%`.
-- README/sample media path: about `90%`.
+- User-facing visualization pipeline: about `94%`.
+- README/sample media path: about `92%`.
 - Topological charge-density physics-validation depth: about `70%`.
 
 The main remaining physics validation item is a true gauge-field instanton or
@@ -63,17 +63,14 @@ Expected metadata:
 
 ## Validation
 
-Current branch: `codex/topological-sample-docs`.
+Current branch: `codex/refresh-readme-examples`.
 
 ```text
+/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
+result: pass, 298 tests, render smoke skipped
+
 /Users/akio/.juliaup/bin/julia --project=. -e 'include("scripts/topology_fixtures/render_topological_density_config_movie.jl"); @assert parse_bool("false", "--show-axis-labels") == false; @assert parse_bool("true", "--show-axis-labels") == true; println("movie helper syntax and parse smoke passed")'
 result: pass
-
-/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
-result: pass, 218 tests, render smoke skipped
-
-/Users/akio/.juliaup/bin/julia --project=. -e 'using Pkg; Pkg.test()'
-result: pass, 218 tests, render smoke skipped
 
 git diff --check
 result: pass
@@ -81,10 +78,9 @@ result: pass
 
 ## Next Steps
 
-1. Finish PR #42, which locks the tracked README sample metadata contract.
-2. Keep this command path as the canonical topological-density README sample
+1. Keep this command path as the canonical topological-density README sample
    reproduction route.
-3. Next code-health work should separate renderer/I/O orchestration around
-   `create_animation` without changing rendered output.
-4. Resume true instanton validation once the Gaugefields.jl-side implementation
+2. Keep the README's direct API example and script-based reproduction command
+   in sync.
+3. Resume true instanton validation once the Gaugefields.jl-side implementation
    is ready.

--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,7 +4,60 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-11 after validating animation draw context extraction.
+Last updated on 2026-05-12 after validating README example refresh.
+
+## Active note: 2026-05-12 README example refresh
+
+- Machine: `Akios-MacBook-Air.local`.
+- Workdir:
+
+```text
+/Users/akio/repository/VisualizingLQCD_v2/VisualizingLQCD.jl
+```
+
+- Branch: `codex/refresh-readme-examples`.
+- Starting point: PR #52 was merged into `main`.
+- Goal:
+  - make the README examples easier to reproduce without changing runtime
+    behavior;
+  - separate the direct `create_animation` API example from the reviewed
+    script-based README sample reproduction path;
+  - keep tracked media and metadata artifacts unchanged.
+- Scope:
+  - README install and example text cleanup;
+  - explicit README sample reproduction command using
+    `scripts/topology_fixtures/render_topological_density_config_movie.jl`;
+  - topological-density sample command memo refresh;
+  - sample artifact contract checks updated for the script command.
+- Current progress estimate:
+  - visualization refactor/user-facing pipeline: about `94%`;
+  - README/sample media path: about `92%`;
+  - physics-validation depth for topological charge density: about `70%`.
+- Main concerns:
+  - README/sample reproduction is now clearer, but the large sample and true
+    instanton validation remain separate work streams;
+  - `Pkg.test()` remains blocked by the existing `Qt6Base_jll` manifest vs
+    registry mismatch until the package environment is deliberately refreshed;
+  - no GLMakie render smoke was run for this branch because it is docs/tests
+    only and does not change render code.
+- Next likely PRs, in order:
+  1. Consider a deliberate package-environment refresh for `Pkg.test`.
+  2. Decide whether to stop `create_animation` refactor here or extract
+     `draw_slice!` behind a small renderer helper.
+  3. Resume true instanton/SU(3)-embedded validation once Gaugefields.jl-side
+     work is ready.
+- Validation:
+
+```text
+/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
+result: pass, 298 tests, render smoke skipped
+
+/Users/akio/.juliaup/bin/julia --project=. -e 'include("scripts/topology_fixtures/render_topological_density_config_movie.jl"); @assert parse_bool("false", "--show-axis-labels") == false; @assert parse_bool("true", "--show-axis-labels") == true; println("movie helper syntax and parse smoke passed")'
+result: pass
+
+git diff --check
+result: pass
+```
 
 ## Active note: 2026-05-11 animation draw context extraction
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -812,6 +812,9 @@ end
     @test occursin("LEVEL_TARGET_TOPOLOGICAL_CHARGE_DENSITY", readme_text)
     @test occursin("RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME", readme_text)
     @test occursin("`abs(q)`", readme_text)
+    @test occursin("render_topological_density_config_movie.jl", readme_text)
+    @test occursin("--output-name $(SAMPLE_BASENAME).mp4", readme_text)
+    @test occursin("--show-axis-labels false", readme_text)
     @test occursin("$(SAMPLE_BASENAME).mp4.metadata.json", readme_text)
     @test !occursin("plaquette_3D_contour_animation32323264beta6.0-gf05hb40flow200-fullturn",
         readme_text)


### PR DESCRIPTION
## Summary
- Split README usage into direct API examples and a reproducible bundled-sample command using `scripts/topology_fixtures/render_topological_density_config_movie.jl`.
- Refresh the topological-density sample command memo with current progress and validation.
- Extend sample artifact contract tests so the README keeps the reviewed script-based reproduction command.

## Validation
- `/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl` pass, 298 tests, render smoke skipped
- `/Users/akio/.juliaup/bin/julia --project=. -e 'include("scripts/topology_fixtures/render_topological_density_config_movie.jl"); @assert parse_bool("false", "--show-axis-labels") == false; @assert parse_bool("true", "--show-axis-labels") == true; println("movie helper syntax and parse smoke passed")'` pass
- `git diff --check` pass

## Note
- This PR does not change rendering code or tracked media artifacts, so no GLMakie render smoke was run.
- `Pkg.test` remains blocked by the existing `Qt6Base_jll 6.10.2+1` manifest vs registry mismatch; this PR does not modify `Project.toml` or `Manifest.toml`.