### PR TITLE
[codex] Add light theme visual review support

### DIFF
--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,7 +4,7 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-13 after starting light theme visual candidates.
+Last updated on 2026-05-13 after user accepted light theme visual candidates.
 
 ## Active note: 2026-05-13 light theme visual candidates
 
@@ -61,24 +61,27 @@ action-density command:
   - white-background action-density movie was generated as a short 32-frame
     review candidate; metadata confirms `render_theme=light`,
     `frame_count=32`, and `cached_slice_count=32`.
+  - User visual review on 2026-05-13: "良さそう"; keep this first light-theme
+    support PR as-is and mark the draft PR ready.
 - Current progress estimate:
   - visualization refactor/user-facing pipeline: about `94%`;
   - README/sample media path: about `92%`;
-  - light-theme polish: about `45%`;
+  - light-theme polish: about `60%`;
   - physics-validation depth for topological charge density: about `70%`.
 - Main concerns:
-  - the first light-theme change is only plumbing plus review artifacts; it does
-    not yet add a light-specific color palette;
-  - action-density light-theme candidates still need a separate check if the
-    user wants white-background action-density movies too;
+  - the first light-theme change is plumbing plus review artifacts, not a
+    dedicated light-specific color palette;
+  - action-density and topological-density light outputs are visually acceptable
+    as first candidates, but future palette tuning may still improve white-slide
+    contrast;
   - `Pkg.test()` remains blocked by the existing `Qt6Base_jll` manifest vs
     registry mismatch until the package environment is deliberately refreshed.
 - Next likely steps:
-  1. Ask the user to review the durable `topological-both/view.html` page.
-  2. If accepted, render a short light-theme topological movie candidate.
-  3. If contrast is weak, test a light-specific positive palette with deeper
+  1. Mark PR #54 ready and merge after review.
+  2. If contrast is later judged weak, test a light-specific positive palette with deeper
      orange/red lows instead of yellow.
-  4. Repeat the same dark/light review for action-density blobs if needed.
+  3. Consider a longer README/sample-style light-theme movie only if a user-facing
+     white-background sample is needed.
 - Validation:
 
 ```text

--- a/docs/codex/visualization_refactor_status.md
+++ b/docs/codex/visualization_refactor_status.md
@@ -4,7 +4,96 @@ This memo tracks the VisualizingLQCD.jl visualization refactor outside the
 `docs/codex/visualization_refactor_v7/` reference directory. Do not edit the v7
 reference materials for status updates.
 
-Last updated on 2026-05-12 after validating README example refresh.
+Last updated on 2026-05-13 after starting light theme visual candidates.
+
+## Active note: 2026-05-13 light theme visual candidates
+
+- Machine: `Akios-MacBook-Air.local`.
+- Workdir:
+
+```text
+/Users/akio/repository/VisualizingLQCD_v2/VisualizingLQCD.jl
+```
+
+- Branch: `codex/light-theme-visual-candidates`.
+- Starting point: PR #53 was merged into `main`.
+- Goal:
+  - make white-background visual review reproducible;
+  - keep existing dark-theme defaults unchanged;
+  - add script-level `--render-theme light|dark` for movies and
+    `--render-theme dark|light|both` for still review pages.
+- Scope so far:
+  - `render_topological_density_config_movie.jl` accepts `--render-theme` and
+    passes it to `create_animation`;
+  - `render_topological_density_config_review.jl` accepts `--render-theme both`
+    so dark/light stills can be compared in one visual-review page;
+  - `scripts/topology_fixtures/README.md` records the light-theme review command;
+  - package tests cover explicit light-theme metadata and override behavior.
+- Review artifacts:
+
+```text
+topological still review scratch:
+  /private/tmp/VisualizingLQCD-light-theme-review-20260513/topological-both/view.html
+topological still review durable:
+  /Users/akio/Downloads/VisualizingLQCD-light-theme-review-20260513/topological-both/view.html
+topological input:
+  /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg
+topological command:
+  /Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_topological_density_config_review.jl --nx 24 --ny 24 --nz 24 --nt 32 --nc 3 --beta 6.0 --input /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg --render-mode volume --render-theme both --slice4 6,5,28,27 --figure-size 560 --output-dir /private/tmp/VisualizingLQCD-light-theme-review-20260513/topological-both
+
+action-density light movie scratch:
+  /private/tmp/VisualizingLQCD-light-theme-review-20260513/action-density-light/view.html
+action-density light movie durable:
+  /Users/akio/Downloads/VisualizingLQCD-light-theme-review-20260513/action-density-light/view.html
+action-density input:
+  /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg
+action-density command:
+  /Users/akio/.juliaup/bin/julia --project=. -e 'using VisualizingLQCD; out="/private/tmp/VisualizingLQCD-light-theme-review-20260513/action-density-light"; mkpath(out); conf="/Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg"; video=joinpath(out,"action_density_light_orbit_sequence.mp4"); metadata=string(video,".metadata.json"); result=create_animation(24,24,24,32,3,video; beta=6.0, filename=conf, metadata_filename=metadata, render_theme=VisualizingLQCD.RENDER_THEME_LIGHT, camera_motion=VisualizingLQCD.CAMERA_MOTION_ORBIT, frame_mode=VisualizingLQCD.FRAME_MODE_SEQUENCE, camera_orbit_turns=1, nloops=1, framerate=8, figure_size=(480,480), show_axis_labels=false, show_render_progress=true); ...'
+```
+
+- Current visual impression:
+  - white-background topological-density volume rendering works technically and
+    is legible;
+  - black-background version still has stronger contrast;
+  - on white, low positive yellow regions are a little less distinct, so a
+    future light-specific positive palette may help if the user prefers this
+    direction.
+  - white-background action-density movie was generated as a short 32-frame
+    review candidate; metadata confirms `render_theme=light`,
+    `frame_count=32`, and `cached_slice_count=32`.
+- Current progress estimate:
+  - visualization refactor/user-facing pipeline: about `94%`;
+  - README/sample media path: about `92%`;
+  - light-theme polish: about `45%`;
+  - physics-validation depth for topological charge density: about `70%`.
+- Main concerns:
+  - the first light-theme change is only plumbing plus review artifacts; it does
+    not yet add a light-specific color palette;
+  - action-density light-theme candidates still need a separate check if the
+    user wants white-background action-density movies too;
+  - `Pkg.test()` remains blocked by the existing `Qt6Base_jll` manifest vs
+    registry mismatch until the package environment is deliberately refreshed.
+- Next likely steps:
+  1. Ask the user to review the durable `topological-both/view.html` page.
+  2. If accepted, render a short light-theme topological movie candidate.
+  3. If contrast is weak, test a light-specific positive palette with deeper
+     orange/red lows instead of yellow.
+  4. Repeat the same dark/light review for action-density blobs if needed.
+- Validation:
+
+```text
+/Users/akio/.juliaup/bin/julia --project=. -e 'include("scripts/topology_fixtures/render_topological_density_config_review.jl"); @assert parse_render_theme("both") == RENDER_THEME_BOTH; @assert render_themes(RENDER_THEME_BOTH) == (VisualizingLQCD.RENDER_THEME_DARK, VisualizingLQCD.RENDER_THEME_LIGHT); println("review render-theme both parser smoke passed")'
+result: pass
+
+/Users/akio/.juliaup/bin/julia --project=. -e 'include("scripts/topology_fixtures/render_topological_density_config_movie.jl"); @assert parse_render_theme("light") == VisualizingLQCD.RENDER_THEME_LIGHT; println("movie render-theme parser smoke passed")'
+result: pass
+
+git diff --check
+result: pass
+
+/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl
+result: pass, 300 tests, render smoke skipped
+```
 
 ## Active note: 2026-05-12 README example refresh
 

--- a/scripts/topology_fixtures/README.md
+++ b/scripts/topology_fixtures/README.md
@@ -27,6 +27,9 @@ It is a thin wrapper around `VisualizingLQCD.create_animation`, intended for
 small reviewed movie runs after the still-review page looks reasonable.
 Use `--show-axis-labels false` for README-style orbit movies; it keeps the grid
 and 3D box but avoids axis-label shimmer during rotation.
+Use `--render-theme light` to render the same scene on a white background, or
+`--render-theme both` in the still-review script to compare dark and light
+themes in one review page.
 
 For volume rendering, the current reviewed baseline uses a `q0.940` lower
 `|q|` body threshold and colors each sign by local `abs(q)`: positive charge is
@@ -62,6 +65,8 @@ Run from the repository root:
 /Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_su2_instanton_fixture_smoke.jl --case-set debug --style-preset all --render-mode volume --no-movie --output-dir /private/tmp/VisualizingLQCD-su2-instanton-fixtures-volume-review
 
 /Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_topological_density_config_review.jl --nx 24 --ny 24 --nz 24 --nt 32 --nc 3 --beta 6.0 --input /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg --render-mode both --slice4 auto --auto-slices 4 --output-dir /private/tmp/VisualizingLQCD-topological-config-review
+
+/Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_topological_density_config_review.jl --nx 24 --ny 24 --nz 24 --nt 32 --nc 3 --beta 6.0 --input /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg --render-mode volume --render-theme both --slice4 auto --auto-slices 4 --output-dir /private/tmp/VisualizingLQCD-topological-light-theme-review
 
 /Users/akio/.juliaup/bin/julia --project=. scripts/topology_fixtures/render_topological_density_config_movie.jl --nx 24 --ny 24 --nz 24 --nt 32 --nc 3 --beta 6.0 --input /Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg --render-mode volume --camera-motion orbit --frame-mode sequence --nloops 2 --framerate 8 --figure-size 480 --show-render-progress true --output-dir /private/tmp/VisualizingLQCD-topological-config-movie-review
 ```

--- a/scripts/topology_fixtures/render_topological_density_config_movie.jl
+++ b/scripts/topology_fixtures/render_topological_density_config_movie.jl
@@ -89,6 +89,15 @@ function parse_camera_motion(raw)
     throw(ArgumentError("--camera-motion should be orbit or static"))
 end
 
+function parse_render_theme(raw)
+    if raw == "dark"
+        return VisualizingLQCD.RENDER_THEME_DARK
+    elseif raw == "light"
+        return VisualizingLQCD.RENDER_THEME_LIGHT
+    end
+    throw(ArgumentError("--render-theme should be dark or light"))
+end
+
 function html_escape(value)
     text = string(value)
     text = replace(text, "&" => "&amp;")
@@ -125,7 +134,7 @@ function render_movie(mode, options)
         topological_style_preset=options.style_preset,
         render_style=render_style_for_mode(mode),
         render_alpha=options.render_alpha,
-        render_theme=VisualizingLQCD.RENDER_THEME_DARK,
+        render_theme=options.render_theme,
         cache_render_slices=options.cache_render_slices,
         figure_size=(options.figure_size, options.figure_size),
         framerate=options.framerate,
@@ -153,6 +162,7 @@ function options_summary_text(options)
         "lattice_size = $((options.nx, options.ny, options.nz, options.nt))",
         "render_mode = $(String(options.render_mode))",
         "style_preset = $(String(options.style_preset))",
+        "render_theme = $(String(options.render_theme))",
         "frame_mode = $(String(options.frame_mode))",
         "camera_motion = $(String(options.camera_motion))",
         "show_axis_labels = $(options.show_axis_labels)",
@@ -359,6 +369,7 @@ function main(args=ARGS)
             "--level-quantiles"),
         color_quantile=parse_optional_float(arg_value(args, "color-quantile", "")),
         render_alpha=parse_optional_float(arg_value(args, "alpha", "")),
+        render_theme=parse_render_theme(arg_value(args, "render-theme", "dark")),
         figure_size=parse(Int, arg_value(args, "figure-size", "560")),
         framerate=parse_optional_int(arg_value(args, "framerate", "")),
         nloops=parse_optional_int(arg_value(args, "nloops", "")),

--- a/scripts/topology_fixtures/render_topological_density_config_review.jl
+++ b/scripts/topology_fixtures/render_topological_density_config_review.jl
@@ -7,6 +7,7 @@ using Printf
 const RENDER_MODE_CONTOUR = :contour
 const RENDER_MODE_VOLUME = :volume
 const RENDER_MODE_BOTH = :both
+const RENDER_THEME_BOTH = :both
 
 function arg_value(args, name, default)
     flag = "--$name"
@@ -45,6 +46,17 @@ function parse_optional_float(raw)
     return parse(Float64, raw)
 end
 
+function parse_render_theme(raw)
+    if raw == "dark"
+        return VisualizingLQCD.RENDER_THEME_DARK
+    elseif raw == "light"
+        return VisualizingLQCD.RENDER_THEME_LIGHT
+    elseif raw == "both"
+        return RENDER_THEME_BOTH
+    end
+    throw(ArgumentError("--render-theme should be dark, light, or both"))
+end
+
 function parse_slice_spec(raw, density; auto_count)
     _, _, _, nt = size(density)
     if raw == "auto"
@@ -63,6 +75,12 @@ function render_modes(render_mode)
     return (render_mode,)
 end
 
+function render_themes(render_theme)
+    render_theme == RENDER_THEME_BOTH &&
+        return (VisualizingLQCD.RENDER_THEME_DARK, VisualizingLQCD.RENDER_THEME_LIGHT)
+    return (render_theme,)
+end
+
 function html_escape(value)
     text = string(value)
     text = replace(text, "&" => "&amp;")
@@ -76,27 +94,27 @@ function html_path_for(path, output_dir)
     return replace(relpath(path, output_dir), "\\" => "/")
 end
 
-function axis_kwargs(title)
+function axis_kwargs(title, theme_settings)
     return (
         xlabel="x [fm]",
         ylabel="y [fm]",
         zlabel="z [fm]",
         title=title,
         aspect=(1, 1, 1),
-        backgroundcolor=:black,
-        xlabelcolor=:white,
-        ylabelcolor=:white,
-        zlabelcolor=:white,
-        titlecolor=:white,
-        xticklabelcolor=:white,
-        yticklabelcolor=:white,
-        zticklabelcolor=:white,
-        xtickcolor=:white,
-        ytickcolor=:white,
-        ztickcolor=:white,
-        xgridcolor=:gray,
-        ygridcolor=:gray,
-        zgridcolor=:gray,
+        backgroundcolor=theme_settings.axis_background,
+        xlabelcolor=theme_settings.text_color,
+        ylabelcolor=theme_settings.text_color,
+        zlabelcolor=theme_settings.text_color,
+        titlecolor=theme_settings.text_color,
+        xticklabelcolor=theme_settings.text_color,
+        yticklabelcolor=theme_settings.text_color,
+        zticklabelcolor=theme_settings.text_color,
+        xtickcolor=theme_settings.text_color,
+        ytickcolor=theme_settings.text_color,
+        ztickcolor=theme_settings.text_color,
+        xgridcolor=theme_settings.grid_color,
+        ygridcolor=theme_settings.grid_color,
+        zgridcolor=theme_settings.grid_color,
         azimuth=VisualizingLQCD.CURRENT_CAMERA_AZIMUTH,
         elevation=VisualizingLQCD.CURRENT_CAMERA_ELEVATION,
         perspectiveness=VisualizingLQCD.CURRENT_CAMERA_MESH_PERSPECTIVENESS,
@@ -126,7 +144,7 @@ function render_contour_slice!(ax, data, setup, x_range, y_range, z_range)
     return objects
 end
 
-function render_review_item(density, slice4, mode, output_dir, options)
+function render_review_item(density, slice4, mode, render_theme, output_dir, options)
     nx, ny, nz, _ = size(density)
     a = VisualizingLQCD.calculate_a(options.beta)
     x_range = (a, a * nx)
@@ -134,12 +152,17 @@ function render_review_item(density, slice4, mode, output_dir, options)
     z_range = (a, a * nz)
     setup = setup_for_mode(density, mode, options)
     data = @view density[:, :, :, slice4]
-    suffix = "$(String(mode))-slice$(slice4)"
+    suffix = "$(String(render_theme))-$(String(mode))-slice$(slice4)"
     png_path = joinpath(output_dir, "$suffix.png")
+    theme_settings = VisualizingLQCD.render_theme_settings(render_theme)
 
     @printf("rendering %-8s slice4=%d levels=%d\n", String(mode), slice4, length(setup.levels))
-    fig = Figure(size=(options.figure_size, options.figure_size), backgroundcolor=:black)
-    ax = Axis3(fig[1, 1]; axis_kwargs("$(String(mode)) / slice4=$slice4")...)
+    fig = Figure(
+        size=(options.figure_size, options.figure_size),
+        backgroundcolor=theme_settings.figure_background)
+    ax = Axis3(fig[1, 1];
+        axis_kwargs("$(String(render_theme)) / $(String(mode)) / slice4=$slice4",
+            theme_settings)...)
     limits!(ax, 0, a * nx, 0, a * ny, 0, a * nz)
     volume_info = nothing
     if mode == RENDER_MODE_VOLUME
@@ -151,7 +174,7 @@ function render_review_item(density, slice4, mode, output_dir, options)
     end
     save(png_path, fig)
     return (
-        label="$(String(mode)) / slice4=$slice4",
+        label="$(String(render_theme)) / $(String(mode)) / slice4=$slice4",
         mode=String(mode),
         slice4=slice4,
         png=png_path,
@@ -369,6 +392,7 @@ function main(args=ARGS)
         output_dir=arg_value(args, "output-dir", "/private/tmp/VisualizingLQCD-topological-config-review"),
         render_mode=parse_render_mode(arg_value(args, "render-mode", "both")),
         style_preset=parse_style_preset(arg_value(args, "style-preset", "balanced")),
+        render_theme=parse_render_theme(arg_value(args, "render-theme", "dark")),
         level_quantiles=parse_optional_quantiles(arg_value(args, "level-quantiles", ""),
             "--level-quantiles"),
         color_quantile=parse_optional_float(arg_value(args, "color-quantile", "")),
@@ -382,9 +406,10 @@ function main(args=ARGS)
     density = load_topological_density(options)
     slices = parse_slice_spec(options.slice4, density; auto_count=options.auto_slices)
     modes = render_modes(options.render_mode)
+    themes = render_themes(options.render_theme)
     results = [
-        render_review_item(density, slice4, mode, options.output_dir, options)
-        for slice4 in slices for mode in modes
+        render_review_item(density, slice4, mode, render_theme, options.output_dir, options)
+        for slice4 in slices for mode in modes for render_theme in themes
     ]
     metadata = Dict(
         "input" => options.input,
@@ -393,6 +418,8 @@ function main(args=ARGS)
         "beta" => options.beta,
         "render_mode" => String(options.render_mode),
         "style_preset" => String(options.style_preset),
+        "render_theme" => String(options.render_theme),
+        "rendered_themes" => [String(theme) for theme in themes],
         "slice4" => options.slice4,
         "selected_slices" => slices,
         "level_quantiles_override" => options.level_quantiles === nothing ?

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -383,6 +383,11 @@ end
 
     @test VisualizingLQCD.render_theme_metadata(
         VisualizingLQCD.RENDER_THEME_DARK)["render_theme"] == "dark"
+    @test VisualizingLQCD.render_theme_metadata(
+        VisualizingLQCD.RENDER_THEME_LIGHT)["figure_background"] == "white"
+    @test VisualizingLQCD.effective_render_theme(
+        VisualizingLQCD.RENDER_STYLE_TOPOLOGICAL_CHARGE_VOLUME,
+        VisualizingLQCD.RENDER_THEME_LIGHT) == VisualizingLQCD.RENDER_THEME_LIGHT
     thermal_setup = VisualizingLQCD.plaquette_display_level_setup(
         [1.0, 4.0, 2.0, 3.0];
         level_target=VisualizingLQCD.LEVEL_TARGET_RAW_HIGH,


### PR DESCRIPTION
## Summary
- Add `--render-theme light|dark` to the topological-density movie helper.
- Add `--render-theme dark|light|both` to the still-review helper so dark/light outputs can be compared in one review page.
- Record light-theme review commands/artifacts in the status memo and topology fixture README.
- Add light-theme metadata/override contract checks.

## Visual Artifacts
- Topological dark/light still review: `file:///Users/akio/Downloads/VisualizingLQCD-light-theme-review-20260513/topological-both/view.html`
- Action-density light movie candidate: `file:///Users/akio/Downloads/VisualizingLQCD-light-theme-review-20260513/action-density-light/view.html`

## Validation
- `/Users/akio/.juliaup/bin/julia --project=. test/runtests.jl` pass, 300 tests, render smoke skipped
- Review helper parser smoke for `--render-theme both` pass
- Movie helper parser smoke for `--render-theme light` pass
- Generated topological dark/light still review page from `/Users/akio/Dropbox/configuration_gauge/Conf24242432beta6.0.ildg`
- Generated action-density light-theme 32-frame review movie from the same configuration; metadata confirms `render_theme=light`, `frame_count=32`, `cached_slice_count=32`
- `git diff --check` pass

## Note
- Visual review accepted by user on 2026-05-13: 「良さそう」.
- Future light-specific palette tuning can stay as a later polish item if white-slide contrast becomes an issue.